### PR TITLE
[FIX] Compile error involving a missing include

### DIFF
--- a/Source/DlgSystem/NYEngineVersionHelpers.h
+++ b/Source/DlgSystem/NYEngineVersionHelpers.h
@@ -53,6 +53,7 @@
 
 #if WITH_EDITOR
 	#if NY_ENGINE_VERSION >= 501
+		#include "Styling/AppStyle.h"
 		using FNYAppStyle = FAppStyle;
 		#define NY_GET_APP_STYLE_NAME() FNYAppStyle::GetAppStyleSetName()
 	#else


### PR DESCRIPTION
The plugin would not compile on our 5.1 config because of the unrecognized identifier `FAppStyle`.
This was fixed by adding a missing include in `NYEngineVersionHelpers.h`.