### PR TITLE
[FIX] Bug fixes

### DIFF
--- a/Source/DlgSystem/DlgHelper.h
+++ b/Source/DlgSystem/DlgHelper.h
@@ -322,7 +322,11 @@ public:
 	template<typename TEnum>
 	static bool ConvertEnumToString(const FString& EnumName, TEnum EnumValue, bool bWithNameSpace, FString& OutEnumValue)
 	{
-		const UEnum* EnumPtr = FindObject<UEnum>(nullptr, *EnumName, true);
+#if NY_ENGINE_VERSION >= 501
+		const UEnum* EnumPtr = FindFirstObject<UEnum>(*EnumName, EFindFirstObjectOptions::ExactClass);
+#else
+		const UEnum* EnumPtr = FindObject<UEnum>(ANY_PACKAGE, *EnumName, true);
+#endif
 		if (!EnumPtr)
 		{
 			OutEnumValue = FString::Printf(TEXT("INVALID EnumName = `%s`"), *EnumName);
@@ -337,7 +341,11 @@ public:
 	template<typename TEnum>
 	static bool ConvertStringToEnum(const FString& String, const FString& EnumName, TEnum& OutEnumValue)
 	{
-		const UEnum* EnumPtr = FindObject<UEnum>(nullptr, *EnumName, true);
+#if NY_ENGINE_VERSION >= 501
+		const UEnum* EnumPtr = FindFirstObject<UEnum>(*EnumName, EFindFirstObjectOptions::ExactClass);
+#else
+		const UEnum* EnumPtr = FindObject<UEnum>(ANY_PACKAGE, *EnumName, true);
+#endif
 		if (!EnumPtr)
 		{
 			return false;
@@ -351,7 +359,11 @@ public:
 	template<typename TEnum>
 	static bool ConvertFNameToEnum(FName Name, const FString& EnumName, TEnum& OutEnumValue)
 	{
-		const UEnum* EnumPtr = FindObject<UEnum>(nullptr, *EnumName, true);
+#if NY_ENGINE_VERSION >= 501
+		const UEnum* EnumPtr = FindFirstObject<UEnum>(*EnumName, EFindFirstObjectOptions::ExactClass);
+#else
+		const UEnum* EnumPtr = FindObject<UEnum>(ANY_PACKAGE, *EnumName, true);
+#endif
 		if (!EnumPtr)
 		{
 			return false;

--- a/Source/DlgSystem/DlgManager.cpp
+++ b/Source/DlgSystem/DlgManager.cpp
@@ -276,7 +276,7 @@ TArray<TWeakObjectPtr<AActor>> UDlgManager::GetAllWeakActorsWithDialogueParticip
 	for (TActorIterator<AActor> Itr(World); Itr; ++Itr)
 	{
 		AActor* Actor = *Itr;
-		if (IsValid(Actor) && !IsValid(Actor) && Actor->GetClass()->ImplementsInterface(UDlgDialogueParticipant::StaticClass()))
+		if (IsValid(Actor) && Actor->GetClass()->ImplementsInterface(UDlgDialogueParticipant::StaticClass()))
 		{
 			Array.Add(Actor);
 		}

--- a/Source/DlgSystem/Tests/DlgIOTesterTypes.cpp
+++ b/Source/DlgSystem/Tests/DlgIOTesterTypes.cpp
@@ -346,7 +346,7 @@ bool FDlgTestStructPrimitives::IsEqual(const Self& Other, FString& OutError) con
 	if (DateTime != Other.DateTime)
 	{
 		bIsEqual = false;
-		OutError += FString::Printf(TEXT("\tThis.DateTime.Ticks (%d) != Other.DateTime.Ticks (%d)\n"), DateTime.GetTicks(), Other.DateTime.GetTicks());
+		OutError += FString::Printf(TEXT("\tThis.DateTime.Ticks (%lld) != Other.DateTime.Ticks (%lld)\n"), DateTime.GetTicks(), Other.DateTime.GetTicks());
 	}
 
 	if (IntPoint != Other.IntPoint)


### PR DESCRIPTION
In UE5.1, calling FindObject with a nullptr for Outer returns nullptr. Epic has added a new API to be used in place of this for looking up Enums.
Also fixed one logic error and a bad specifier in test code.