### PR TITLE
Switch to TSoftClassPtr for DefaultCustomNodeDataClass setting

### DIFF
--- a/Source/DlgSystem/DlgSystemSettings.h
+++ b/Source/DlgSystem/DlgSystemSettings.h
@@ -303,7 +303,7 @@ public:
 
 	// Default class to use for custom node data
 	UPROPERTY(Category = "Dialogue", Config, EditAnywhere)
-	TAssetSubclassOf<UDlgNodeData> DefaultCustomNodeDataClass;
+	TSoftClassPtr<UDlgNodeData> DefaultCustomNodeDataClass;
 
 	// How the Blueprint class pricker looks like
 	UPROPERTY(Category = "Blueprint", Config, EditAnywhere)

--- a/Source/DlgSystem/DlgSystemSettings.h
+++ b/Source/DlgSystem/DlgSystemSettings.h
@@ -303,7 +303,7 @@ public:
 
 	// Default class to use for custom node data
 	UPROPERTY(Category = "Dialogue", Config, EditAnywhere)
-	TSubclassOf<UDlgNodeData> DefaultCustomNodeDataClass;
+	TAssetSubclassOf<UDlgNodeData> DefaultCustomNodeDataClass;
 
 	// How the Blueprint class pricker looks like
 	UPROPERTY(Category = "Blueprint", Config, EditAnywhere)

--- a/Source/DlgSystem/Nodes/DlgNode_Speech.cpp
+++ b/Source/DlgSystem/Nodes/DlgNode_Speech.cpp
@@ -10,11 +10,11 @@
 void UDlgNode_Speech::OnCreatedInEditor()
 {
 	const UDlgSystemSettings* Settings = GetDefault<UDlgSystemSettings>();
-	if (NodeData != nullptr || Settings == nullptr || Settings->DefaultCustomNodeDataClass == nullptr)
+	if (NodeData != nullptr || Settings == nullptr || Settings->DefaultCustomNodeDataClass.IsNull())
 	{
 		return;
 	}
-	NodeData = NewObject<UDlgNodeData>(this, Settings->DefaultCustomNodeDataClass, NAME_None, GetMaskedFlags(RF_PropagateToSubObjects), NULL);
+	NodeData = NewObject<UDlgNodeData>(this, Settings->DefaultCustomNodeDataClass.Get(), NAME_None, GetMaskedFlags(RF_PropagateToSubObjects), NULL);
 }
 
 

--- a/Source/DlgSystem/Nodes/DlgNode_SpeechSequence.cpp
+++ b/Source/DlgSystem/Nodes/DlgNode_SpeechSequence.cpp
@@ -19,7 +19,7 @@ void UDlgNode_SpeechSequence::PostEditChangeProperty(FPropertyChangedEvent& Prop
 void UDlgNode_SpeechSequence::InitializeNodeDataOnArrayAdd(FPropertyChangedEvent& PropertyChangedEvent)
 {
 	const UDlgSystemSettings* Settings = GetDefault<UDlgSystemSettings>();
-	if (Settings == nullptr || Settings->DefaultCustomNodeDataClass == nullptr)
+	if (Settings == nullptr || Settings->DefaultCustomNodeDataClass.IsNull())
 	{
 		return;
 	}
@@ -37,7 +37,7 @@ void UDlgNode_SpeechSequence::InitializeNodeDataOnArrayAdd(FPropertyChangedEvent
 	}
 
 	check(SpeechSequence.IsValidIndex(Index));
-	SpeechSequence[Index].NodeData = NewObject<UDlgNodeData>(this, Settings->DefaultCustomNodeDataClass, NAME_None, GetMaskedFlags(RF_PropagateToSubObjects), NULL);
+	SpeechSequence[Index].NodeData = NewObject<UDlgNodeData>(this, Settings->DefaultCustomNodeDataClass.Get(), NAME_None, GetMaskedFlags(RF_PropagateToSubObjects), NULL);
 }
 #endif
 


### PR DESCRIPTION
TSubclassOf forces the editor to load the class when it's loading settings which can be far too early for certain classes that reference objects in the project instead of the engine.