### PR TITLE
Use Class "DisplayName" When Showing Events/Conditions On The Graph.

### DIFF
--- a/Source/DlgSystem/DlgConditionCustom.h
+++ b/Source/DlgSystem/DlgConditionCustom.h
@@ -29,7 +29,7 @@ public:
 	FString GetEditorDisplayString(UDlgDialogue* OwnerDialogue, FName ParticipantName);
 	virtual FString GetEditorDisplayString_Implementation(UDlgDialogue* OwnerDialogue, FName ParticipantName)
 	{
-		return FString(TEXT("[")) + ParticipantName.ToString() + FString(TEXT("] ")) + GetName();
+		return FString(TEXT("[")) + ParticipantName.ToString() + FString(TEXT("] ")) + GetClass()->GetDisplayNameText().ToString();
 	}
 };
 

--- a/Source/DlgSystem/DlgEventCustom.h
+++ b/Source/DlgSystem/DlgEventCustom.h
@@ -26,7 +26,7 @@ public:
 	virtual FString GetEditorDisplayString_Implementation(UDlgDialogue* OwnerDialogue, FName ParticipantName)
 	{
 		const FString TargetPreFix = (ParticipantName != NAME_None) ? (FString(TEXT("[")) + ParticipantName.ToString() + FString(TEXT("] "))) : TEXT("");
-		return TargetPreFix + GetName();
+		return TargetPreFix + GetClass()->GetDisplayNameText().ToString();
 	}
 };
 


### PR DESCRIPTION
Allows users to have their class "DisplayName" displayed for their custom events/conditions in the graph, if available.
It also gets rid of the _C_0 at the end of the displayed names even if no "DisplayName" is defined.