### PR TITLE
[C] Fix static_assert compile error on 5.4 preview

### DIFF
--- a/Source/DlgSystemEditor/DlgEditorUtilities.cpp
+++ b/Source/DlgSystemEditor/DlgEditorUtilities.cpp
@@ -78,7 +78,8 @@ void FDlgEditorUtilities::LoadAllDialoguesAndCheckGUIDs()
 			LogDlgSystemEditor,
 			Fatal,
 			TEXT("(╯°□°）╯︵ ┻━┻ Congrats, you just broke the universe, are you even human? Now please go and proove an NP complete problem."
-				"The chance of generating two equal random FGuid (picking 4, uint32 numbers) is p = 9.3132257 * 10^(-10) % (or something like this)")
+				"The chance of generating two equal random FGuid (picking 4, uint32 numbers) is p = 9.3132257 * 10^(-10) %% (or something like this)"),
+			*Dialogue->GetPathName(), *Dialogue->GetGUID().ToString()
 		)
 	}
 }

--- a/Source/DlgSystemEditor/DlgEditorUtilities.cpp
+++ b/Source/DlgSystemEditor/DlgEditorUtilities.cpp
@@ -78,8 +78,7 @@ void FDlgEditorUtilities::LoadAllDialoguesAndCheckGUIDs()
 			LogDlgSystemEditor,
 			Fatal,
 			TEXT("(╯°□°）╯︵ ┻━┻ Congrats, you just broke the universe, are you even human? Now please go and proove an NP complete problem."
-				"The chance of generating two equal random FGuid (picking 4, uint32 numbers) is p = 9.3132257 * 10^(-10) %% (or something like this)"),
-			*Dialogue->GetPathName(), *Dialogue->GetGUID().ToString()
+				"The chance of generating two equal random FGuid (picking 4, uint32 numbers) is p = 9.3132257 * 10^(-10) %% (or something like this)")
 		)
 	}
 }


### PR DESCRIPTION
Thought I'd have a play around with 5.4 Preview and found that Dlgsystem's build fails on [line 77 in `Source\DlgSystemEditor\DlgEditorUtilities.cpp` ](https://github.com/NotYetGames/DlgSystem/blob/d0ba893af0c1042b83b7dca3ff1295d266182ee7/Source/DlgSystemEditor/DlgEditorUtilities.cpp#L77)

The error:

```
static_assert failed: 'not enough arguments provided to format string.'
```

So I added `*Dialogue->GetPathName(), *Dialogue->GetGUID().ToString()` just to see. 

Then I got this error:

```
static_assert failed: 'unsupported '%' format specifier. (to print a percent sign, write '%%'.)'	
```

So I added an extra %. 

Then I was able to compile the plugin and open the project.

Then realised that I didn't need the format string variable.
