### PR TITLE
Add support for Unreal 5.6

### DIFF
--- a/Source/DlgSystem/NYEngineVersionHelpers.h
+++ b/Source/DlgSystem/NYEngineVersionHelpers.h
@@ -62,3 +62,15 @@
 		#define NY_GET_APP_STYLE_NAME() FNYAppStyle::GetStyleSetName()
 	#endif // NY_ENGINE_VERSION >= 501
 #endif // WITH_EDITOR
+
+// Unreal 5.6 switched to using float instead of double vectors in Slate code
+#if NY_ENGINE_VERSION >= 506
+	using FNYVector2f = FVector2f;
+	using FNYBox2f = FBox2f;
+	using FNYLocationVector2f = const FVector2f&; // For use in the signature of FEdGraphSchemaAction::PerformAction() overrides to avoid ugly #ifdefs
+#else
+	using FNYVector2f = FVector2D;
+	using FNYBox2f = FBox2D;
+	using FNYLocationVector2f = const FVector2D;
+#endif
+

--- a/Source/DlgSystem/Tests/DlgTesterHelper.h
+++ b/Source/DlgSystem/Tests/DlgTesterHelper.h
@@ -42,7 +42,7 @@ public:
 				{
 					if (bIsPrimitive)
 					{
-						OutError += FString::Printf(TEXT("\tThis.%s[%d] (%d) != Other.%s[%d] (%d)\n"),
+						OutError += FString::Printf(TEXT("\tThis.%s[%d] (%s) != Other.%s[%d] (%s)\n"),
 							*PropertyName, Index, *GetArrayTypeAsString(ThisArray[Index]), *PropertyName, Index, *GetArrayTypeAsString(OtherArray[Index]));
 					}
 					else

--- a/Source/DlgSystemEditor/DlgEditorUtilities.cpp
+++ b/Source/DlgSystemEditor/DlgEditorUtilities.cpp
@@ -1132,7 +1132,7 @@ UK2Node_Event* FDlgEditorUtilities::BlueprintGetEvent(UBlueprint* Blueprint, FNa
 	return nullptr;
 }
 
-UEdGraphNode_Comment* FDlgEditorUtilities::BlueprintAddComment(UBlueprint* Blueprint, const FString& CommentString, FVector2D Location)
+UEdGraphNode_Comment* FDlgEditorUtilities::BlueprintAddComment(UBlueprint* Blueprint, const FString& CommentString, FNYVector2f Location)
 {
 	if (!Blueprint || Blueprint->BlueprintType != BPTYPE_Normal || Blueprint->UbergraphPages.Num() == 0)
 	{

--- a/Source/DlgSystemEditor/DlgEditorUtilities.h
+++ b/Source/DlgSystemEditor/DlgEditorUtilities.h
@@ -6,6 +6,7 @@
 
 #include "Editor/Graph/DialogueGraph.h"
 #include "DlgSystem/Nodes/DlgNode.h"
+#include "DlgSystem/NYEngineVersionHelpers.h"
 
 enum class EDlgBlueprintOpenType : uint8
 {
@@ -200,11 +201,11 @@ public:
 	static EAppReturnType::Type ShowMessageBox(EAppMsgType::Type MsgType, const FString& Text, const FString& Caption);
 
 	// Returns true if the TestPoint is inside the Geometry.
-	static bool IsPointInsideGeometry(const FVector2D& TestPoint, const FGeometry& Geometry)
+	static bool IsPointInsideGeometry(const FNYVector2f& TestPoint, const FGeometry& Geometry)
 	{
-		TArray<FVector2D> GeometryPoints;
+		TArray<FNYVector2f> GeometryPoints;
 		FGeometryHelper::ConvertToPoints(Geometry, GeometryPoints);
-		return FBox2D(GeometryPoints).IsInside(TestPoint);
+		return FNYBox2f(GeometryPoints).IsInside(TestPoint);
 	}
 
 	/**
@@ -266,7 +267,7 @@ public:
 	static UK2Node_Event* BlueprintGetEvent(UBlueprint* Blueprint, FName EventName, UClass* EventClassSignature);
 
 	// Adds a comment to the Blueprint
-	static UEdGraphNode_Comment* BlueprintAddComment(UBlueprint* Blueprint, const FString& CommentString, FVector2D Location = FVector2D::ZeroVector);
+	static UEdGraphNode_Comment* BlueprintAddComment(UBlueprint* Blueprint, const FString& CommentString, FNYVector2f Location = FNYVector2f::ZeroVector);
 
 	static void RefreshDialogueEditorForGraph(const UEdGraph* Graph);
 

--- a/Source/DlgSystemEditor/Editor/DlgEditor.cpp
+++ b/Source/DlgSystemEditor/Editor/DlgEditor.cpp
@@ -515,7 +515,12 @@ void FDlgEditor::BindEditorCommands()
 		FExecuteAction::CreateLambda([this]
 		{
 			FDlgNewComment_GraphSchemaAction CommentAction;
-			CommentAction.PerformAction(DialogueBeingEdited->GetGraph(), nullptr, GraphEditorView->GetPasteLocation());
+#if NY_ENGINE_VERSION >= 506
+			FVector2f PasteLocation = GraphEditorView->GetPasteLocation2f();
+#else
+			FVector2D PasteLocation = GraphEditorView->GetPasteLocation();
+#endif
+			CommentAction.PerformAction(DialogueBeingEdited->GetGraph(), nullptr, PasteLocation);
 		})
 	);
 
@@ -1122,10 +1127,15 @@ bool FDlgEditor::CanCopyNodes() const
 
 void FDlgEditor::OnCommandPasteNodes()
 {
-	PasteNodesHere(GraphEditorView->GetPasteLocation());
+#if NY_ENGINE_VERSION >= 506
+	FVector2f PasteLocation = GraphEditorView->GetPasteLocation2f();
+#else
+	FVector2D PasteLocation = GraphEditorView->GetPasteLocation();
+#endif
+	PasteNodesHere(PasteLocation);
 }
 
-void FDlgEditor::PasteNodesHere(const FVector2D& Location)
+void FDlgEditor::PasteNodesHere(const FNYVector2f& Location)
 {
 	// Undo/Redo support
 	const FScopedTransaction Transaction(FGenericCommands::Get().Paste->GetDescription());
@@ -1149,7 +1159,7 @@ void FDlgEditor::PasteNodesHere(const FVector2D& Location)
 
 	// Step 1. Calculate average position
 	// Average position of nodes so we can move them while still maintaining relative distances to each other
-	FVector2D AvgNodePosition(0.0f, 0.0f);
+	FVector2f AvgNodePosition(0.0f, 0.0f);
 	for (UEdGraphNode* Node : PastedNodes)
 	{
 		AvgNodePosition.X += Node->NodePosX;

--- a/Source/DlgSystemEditor/Editor/DlgEditor.h
+++ b/Source/DlgSystemEditor/Editor/DlgEditor.h
@@ -253,7 +253,7 @@ private:
 	void OnCommandPasteNodes();
 
 	// Paste the nodes at the specified Location.
-	void PasteNodesHere(const FVector2D& Location);
+	void PasteNodesHere(const FNYVector2f& Location);
 
 	// Whether we are able to paste from the clipboard
 	bool CanPasteNodes() const;

--- a/Source/DlgSystemEditor/Editor/Graph/DlgGraphConnectionDrawingPolicy.cpp
+++ b/Source/DlgSystemEditor/Editor/Graph/DlgGraphConnectionDrawingPolicy.cpp
@@ -171,8 +171,9 @@ void FDlgGraphConnectionDrawingPolicy::DrawConnection(
 			{
 				const FVector2D Point2 = FMath::CubicInterp(P0, P0Tangent, P1, P1Tangent, TestAlpha + StepInterval);
 
-				const FVector2D ClosestPointToSegment = FMath::ClosestPointOnSegment2D(LocalMousePosition, Point1, Point2);
-				const float DistanceSquared = (LocalMousePosition - ClosestPointToSegment).SizeSquared();
+				const FVector2D LocalMousePosition2D(LocalMousePosition.X, LocalMousePosition.Y);
+				const FVector2D ClosestPointToSegment = FMath::ClosestPointOnSegment2D(LocalMousePosition2D, Point1, Point2);
+				const float DistanceSquared = (LocalMousePosition2D - ClosestPointToSegment).SizeSquared();
 
 				if (DistanceSquared < ClosestDistanceSquared)
 				{

--- a/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgConvertSpeechNodesToSpeechSequence_GraphSchemaAction.cpp
+++ b/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgConvertSpeechNodesToSpeechSequence_GraphSchemaAction.cpp
@@ -15,7 +15,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // FDlgConvertSpeechNodesToSpeechSequence_GraphSchemaAction
 UEdGraphNode* FDlgConvertSpeechNodesToSpeechSequence_GraphSchemaAction::PerformAction(UEdGraph* ParentGraph, UEdGraphPin* FromPin,
-	const FVector2D Location, bool bSelectNewNode/* = true*/)
+	FNYLocationVector2f Location, bool bSelectNewNode/* = true*/)
 {
 	// Should have been stopped in GetConvertActions
 	check(SelectedGraphNodes.Num() > 0);

--- a/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgConvertSpeechNodesToSpeechSequence_GraphSchemaAction.h
+++ b/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgConvertSpeechNodesToSpeechSequence_GraphSchemaAction.h
@@ -3,6 +3,7 @@
 
 #include "EdGraph/EdGraphSchema.h"
 #include "Templates/SubclassOf.h"
+#include "DlgSystem/NYEngineVersionHelpers.h"
 
 #include "DlgConvertSpeechNodesToSpeechSequence_GraphSchemaAction.generated.h"
 
@@ -31,7 +32,7 @@ struct DLGSYSTEMEDITOR_API FDlgConvertSpeechNodesToSpeechSequence_GraphSchemaAct
 	) : FEdGraphSchemaAction(InNodeCategory, InMenuDesc, InToolTip, InGrouping), SelectedGraphNodes(InSelectedGraphNodes) {}
 
 	//~ Begin FEdGraphSchemaAction Interface
-	UEdGraphNode* PerformAction(UEdGraph* ParentGraph, UEdGraphPin* FromPin, const FVector2D Location, bool bSelectNewNode = true) override;
+	UEdGraphNode* PerformAction(UEdGraph* ParentGraph, UEdGraphPin* FromPin, FNYLocationVector2f Location, bool bSelectNewNode = true) override;
 	//~ End FEdGraphSchemaAction Interface
 
 private:

--- a/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgConvertSpeechSequenceNodeToSpeechNodes_GraphSchemaAction.cpp
+++ b/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgConvertSpeechSequenceNodeToSpeechNodes_GraphSchemaAction.cpp
@@ -15,7 +15,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // FDlgConvertSpeechSequenceNodeToSpeechNodes_GraphSchemaAction
 UEdGraphNode* FDlgConvertSpeechSequenceNodeToSpeechNodes_GraphSchemaAction::PerformAction(UEdGraph* ParentGraph, UEdGraphPin* FromPin,
-	const FVector2D Location, bool bSelectNewNode/* = false*/)
+	FNYLocationVector2f Location, bool bSelectNewNode/* = false*/)
 {
 	check(SelectedSpeechSequenceGraphNode);
 	check(SelectedSpeechSequenceGraphNode->IsSpeechSequenceNode());
@@ -23,8 +23,8 @@ UEdGraphNode* FDlgConvertSpeechSequenceNodeToSpeechNodes_GraphSchemaAction::Perf
 
 	UDlgDialogue* Dialogue = FDlgEditorUtilities::GetDialogueForGraph(ParentGraph);
 	const UEdGraphSchema* GraphSchema = ParentGraph->GetSchema();
-	const FVector2D PositionOffset(0.f, GetDefault<UDlgSystemSettings>()->OffsetBetweenRowsY);
-	FVector2D Position = Location;
+	const FNYVector2f PositionOffset(0.f, GetDefault<UDlgSystemSettings>()->OffsetBetweenRowsY);
+	FNYVector2f Position = Location;
 
 	const UDlgNode_SpeechSequence& SpeechSequence_DialogueNode = SelectedSpeechSequenceGraphNode->GetDialogueNode<UDlgNode_SpeechSequence>();
 	const TArray<FDlgSpeechSequenceEntry>& SpeechSequenceEntries = SpeechSequence_DialogueNode.GetNodeSpeechSequence();

--- a/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgConvertSpeechSequenceNodeToSpeechNodes_GraphSchemaAction.h
+++ b/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgConvertSpeechSequenceNodeToSpeechNodes_GraphSchemaAction.h
@@ -3,6 +3,7 @@
 
 #include "EdGraph/EdGraphSchema.h"
 #include "Templates/SubclassOf.h"
+#include "DlgSystem/NYEngineVersionHelpers.h"
 
 #include "DlgConvertSpeechSequenceNodeToSpeechNodes_GraphSchemaAction.generated.h"
 
@@ -31,7 +32,7 @@ struct DLGSYSTEMEDITOR_API FDlgConvertSpeechSequenceNodeToSpeechNodes_GraphSchem
 	) : FEdGraphSchemaAction(InNodeCategory, InMenuDesc, InToolTip, InGrouping), SelectedSpeechSequenceGraphNode(InSelectedSpeechSequenceGraphNode) {}
 
 	//~ Begin FEdGraphSchemaAction Interface
-	UEdGraphNode* PerformAction(UEdGraph* ParentGraph, UEdGraphPin* FromPin, const FVector2D Location, bool bSelectNewNode = false) override;
+	UEdGraphNode* PerformAction(UEdGraph* ParentGraph, UEdGraphPin* FromPin, FNYLocationVector2f Location, bool bSelectNewNode = false) override;
 	//~ End FEdGraphSchemaAction Interface
 
 private:

--- a/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgNewComment_GraphSchemaAction.cpp
+++ b/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgNewComment_GraphSchemaAction.cpp
@@ -10,13 +10,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // FDlgNewComment_GraphSchemaAction
 UEdGraphNode* FDlgNewComment_GraphSchemaAction::PerformAction(UEdGraph* ParentGraph, UEdGraphPin* FromPin,
-	const FVector2D Location, bool bSelectNewNode/* = true*/)
+	FNYLocationVector2f Location, bool bSelectNewNode/* = true*/)
 {
 	// Add menu item for creating comment boxes
 	UEdGraphNode_Comment* CommentTemplate = NewObject<UEdGraphNode_Comment>();
 
 	// Wrap comment around other nodes, this makes it possible to select other nodes and press the "C" key on the keyboard.
-	FVector2D SpawnLocation = Location;
+	FNYVector2f SpawnLocation = Location;
 	FSlateRect Bounds;
 	if (FDlgEditorUtilities::GetBoundsForSelectedNodes(ParentGraph, Bounds, 50.0f))
 	{

--- a/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgNewComment_GraphSchemaAction.h
+++ b/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgNewComment_GraphSchemaAction.h
@@ -3,6 +3,7 @@
 
 #include "EdGraph/EdGraphSchema.h"
 #include "Templates/SubclassOf.h"
+#include "DlgSystem/NYEngineVersionHelpers.h"
 
 #include "DlgNewComment_GraphSchemaAction.generated.h"
 
@@ -19,6 +20,6 @@ struct DLGSYSTEMEDITOR_API FDlgNewComment_GraphSchemaAction : public FEdGraphSch
 		: FEdGraphSchemaAction(InNodeCategory, InMenuDesc, InToolTip, InGrouping) {}
 
 	//~ Begin FEdGraphSchemaAction Interface
-	UEdGraphNode* PerformAction(UEdGraph* ParentGraph, UEdGraphPin* FromPin, const FVector2D Location, bool bSelectNewNode = true) override;
+	UEdGraphNode* PerformAction(UEdGraph* ParentGraph, UEdGraphPin* FromPin, FNYLocationVector2f Location, bool bSelectNewNode = true) override;
 	//~ End FEdGraphSchemaAction Interface
 };

--- a/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgNewNode_GraphSchemaAction.cpp
+++ b/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgNewNode_GraphSchemaAction.cpp
@@ -15,7 +15,7 @@
 UEdGraphNode* FDlgNewNode_GraphSchemaAction::PerformAction(
 	UEdGraph* ParentGraph,
 	UEdGraphPin* FromPin,
-	const FVector2D Location,
+	FNYLocationVector2f Location,
 	bool bSelectNewNode/* = true*/
 )
 {
@@ -43,7 +43,7 @@ UEdGraphNode* FDlgNewNode_GraphSchemaAction::CreateNode(
 	UDlgDialogue* Dialogue,
 	UEdGraph* ParentGraph,
 	UEdGraphPin* FromPin,
-	FVector2D Location,
+	FNYVector2f Location,
 	bool bSelectNewNode
 )
 {

--- a/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgNewNode_GraphSchemaAction.h
+++ b/Source/DlgSystemEditor/Editor/Graph/SchemaActions/DlgNewNode_GraphSchemaAction.h
@@ -5,6 +5,7 @@
 #include "Templates/SubclassOf.h"
 
 #include "DlgSystem/Nodes/DlgNode.h"
+#include "DlgSystem/NYEngineVersionHelpers.h"
 
 #include "DlgNewNode_GraphSchemaAction.generated.h"
 
@@ -30,7 +31,7 @@ public:
 	) : FEdGraphSchemaAction(InNodeCategory, InMenuDesc, InToolTip, InGrouping), CreateNodeType(InCreateNodeType) {}
 
 	//~ Begin FEdGraphSchemaAction Interface
-	UEdGraphNode* PerformAction(UEdGraph* ParentGraph, UEdGraphPin* FromPin, const FVector2D Location, bool bSelectNewNode = true) override;
+	UEdGraphNode* PerformAction(UEdGraph* ParentGraph, UEdGraphPin* FromPin, FNYLocationVector2f Location, bool bSelectNewNode = true) override;
 	//~ End FEdGraphSchemaAction Interface
 
 	// Spawns a new UDialogueGraphNode of type GraphNodeType that must have a valid DialogueNode of TSubclassOf<UDlgNode>
@@ -38,7 +39,7 @@ public:
 	static GraphNodeType* SpawnGraphNodeWithDialogueNodeFromTemplate(
 		UEdGraph* ParentGraph,
 		TSubclassOf<UDlgNode> CreateNodeType,
-		const FVector2D Location,
+		const FNYVector2f Location,
 		bool bSelectNewNode = true
 	)
 	{
@@ -48,7 +49,7 @@ public:
 
 private:
 	/** Creates a new dialogue node from the template */
-	UEdGraphNode* CreateNode(UDlgDialogue* Dialogue, UEdGraph* ParentGraph, UEdGraphPin* FromPin, FVector2D Location, bool bSelectNewNode);
+	UEdGraphNode* CreateNode(UDlgDialogue* Dialogue, UEdGraph* ParentGraph, UEdGraphPin* FromPin, FNYVector2f Location, bool bSelectNewNode);
 
 	/** Connects new node to output of selected nodes */
 //	void ConnectToSelectedNodes(UDialogueNode* NewNodeclass, UEdGraph* ParentGraph) const;

--- a/Source/DlgSystemEditor/Editor/Nodes/SDlgGraphPin.cpp
+++ b/Source/DlgSystemEditor/Editor/Nodes/SDlgGraphPin.cpp
@@ -6,6 +6,7 @@
 #include "Math/UnitConversion.h"
 #include "GraphEditorDragDropAction.h"
 #include "DragAndDrop/AssetDragDropOp.h"
+#include "DlgSystem/NYEngineVersionHelpers.h"
 
 #include "DialogueGraphNode_Edge.h"
 #include "DialogueGraphNode.h"
@@ -318,7 +319,7 @@ FReply SDlgGraphPin::OnAltAndLeftMouseButtonDown(const FGeometry& SenderGeometry
 	TSharedPtr<SGraphNode> ThisOwnerNodeWidget = OwnerNodePtr.Pin();
 	check(ThisOwnerNodeWidget.IsValid());
 	const UDialogueGraphSchema* Schema = CastChecked<UDialogueGraphSchema>(GraphPinObj->GetSchema());
-	const FVector2D& MouseLocation = MouseEvent.GetScreenSpacePosition();
+	const FNYVector2f& MouseLocation = MouseEvent.GetScreenSpacePosition();
 
 	// Is the click inside the node?
 	if (FDlgEditorUtilities::IsPointInsideGeometry(MouseLocation, ThisOwnerNodeWidget->GetCachedGeometry()))
@@ -397,7 +398,7 @@ FText SDlgGraphPin::GetTooltipText() const
 //	return HoverText;
 }
 
-UEdGraphPin* SDlgGraphPin::GetBestLinkedToPinFromSplineMousePosition(const FVector2D& MousePosition) const
+UEdGraphPin* SDlgGraphPin::GetBestLinkedToPinFromSplineMousePosition(const FNYVector2f& MousePosition) const
 {
 	/*
 	ASSUMPTION: that the MousePosition is on a spline (wire) or near a wire
@@ -428,11 +429,11 @@ UEdGraphPin* SDlgGraphPin::GetBestLinkedToPinFromSplineMousePosition(const FVect
 	check(ThisGraphNodeWidget.IsValid());
 
 	// Find P and MP
-	const FVector2D ThisGraphNodeClosestPosition = FGeometryHelper::FindClosestPointOnGeom(
+	const FNYVector2f ThisGraphNodeClosestPosition = FGeometryHelper::FindClosestPointOnGeom(
 		ThisGraphNodeWidget->GetCachedGeometry(),
 		MousePosition
 	);
-	const FVector2D MP = (ThisGraphNodeClosestPosition - MousePosition).GetSafeNormal();
+	const FNYVector2f MP = (ThisGraphNodeClosestPosition - MousePosition).GetSafeNormal();
 
 	// Iterate over all edges, find the best one
 	const TArray<UDialogueGraphNode_Edge*> ChildGraphEdges = ThisGraphNode->GetChildEdgeNodes();
@@ -448,11 +449,11 @@ UEdGraphPin* SDlgGraphPin::GetBestLinkedToPinFromSplineMousePosition(const FVect
 		check(ChildNodeWidget.IsValid());
 
 		// Find C (aka ClosestPointOnChild)
-		const FVector2D ClosestPointOnChild = FGeometryHelper::FindClosestPointOnGeom(ChildNodeWidget->GetCachedGeometry(), MousePosition);
+		const FNYVector2f ClosestPointOnChild = FGeometryHelper::FindClosestPointOnGeom(ChildNodeWidget->GetCachedGeometry(), MousePosition);
 
 		// Find angle between vectors
-		const FVector2D MC = (ClosestPointOnChild - MousePosition).GetSafeNormal();
-		const float DotProduct = FMath::Abs(FVector2D::DotProduct(MC, MP));
+		const FNYVector2f MC = (ClosestPointOnChild - MousePosition).GetSafeNormal();
+		const float DotProduct = FMath::Abs(FNYVector2f::DotProduct(MC, MP));
 		if (DotProduct > BestDotProduct)
 		{
 			// found new angle approaching 180 degrees

--- a/Source/DlgSystemEditor/Editor/Nodes/SDlgGraphPin.h
+++ b/Source/DlgSystemEditor/Editor/Nodes/SDlgGraphPin.h
@@ -131,7 +131,7 @@ protected:
 	FText GetTooltipText() const;
 
 	/** Gets the Index in the current pin LinkeTo array that corresponds to the MousePosition on the wire/spline. */
-	UEdGraphPin* GetBestLinkedToPinFromSplineMousePosition(const FVector2D& MousePosition) const;
+	UEdGraphPin* GetBestLinkedToPinFromSplineMousePosition(const FNYVector2f& MousePosition) const;
 
 	/** Gets the pin border */
 	const FSlateBrush* GetPinBorder() const


### PR DESCRIPTION
This mostly consisted in replacing FVector2D usages with FVector2f, since Unreal 5.6 decided to transition its Slate code to using floats instead of doubles