### PR TITLE
Only detect transactional DlgParticipants

### DIFF
--- a/Source/DlgSystem/DlgManager.cpp
+++ b/Source/DlgSystem/DlgManager.cpp
@@ -581,7 +581,8 @@ void UDlgManager::GatherParticipantsRecursive(UObject* Object, TArray<UObject*>&
 	}
 
 	AlreadyVisited.Add(Object);
-	if (Object->GetClass()->ImplementsInterface(UDlgDialogueParticipant::StaticClass()))
+	if (Object->HasAllFlags(RF_Transactional) &&
+		Object->GetClass()->ImplementsInterface(UDlgDialogueParticipant::StaticClass()))
 	{
 		Array.Add(Object);
 	}


### PR DESCRIPTION
Should fix #17.

Please make sure the flags are relevant for most cases.