### PR TITLE
 Add JSON import/export support for dialogues

### DIFF
--- a/Source/DlgSystemEditor/Commandlets/DlgHumanReadableTextCommandlet.cpp
+++ b/Source/DlgSystemEditor/Commandlets/DlgHumanReadableTextCommandlet.cpp
@@ -368,7 +368,17 @@ bool UDlgHumanReadableTextCommandlet::ImportHumanReadableFormatIntoDialogue(cons
 		const bool bIsRootNode = HumanNode.NodeIndex <= RootNodeIndex;
 
 		// Node
-		UDlgNode* Node = bIsRootNode ? Dialogue->GetMutableStartNodes()[FMath::Abs(RootNodeIndex) - 1] : Dialogue->GetMutableNodeFromIndex(HumanNode.NodeIndex);
+		const int32 StartNodeIndex = FMath::Abs(HumanNode.NodeIndex) - 1;
+		UDlgNode* Node = nullptr;
+		if (bIsRootNode)
+		{
+			TArray<UDlgNode*>& StartNodes = Dialogue->GetMutableStartNodes();
+			Node = StartNodes.IsValidIndex(StartNodeIndex) ? StartNodes[StartNodeIndex] : nullptr;
+		}
+		else
+		{
+			Node = Dialogue->GetMutableNodeFromIndex(HumanNode.NodeIndex);
+		}
 		if (Node == nullptr)
 		{
 			UE_LOG(LogDlgHumanReadableTextCommandlet, Warning, TEXT("Invalid node index = %d, in Dialogue = `%s`. Ignoring."), HumanNode.NodeIndex, *Dialogue->GetPathName());

--- a/Source/DlgSystemEditor/Commandlets/DlgHumanReadableTextCommandlet.cpp
+++ b/Source/DlgSystemEditor/Commandlets/DlgHumanReadableTextCommandlet.cpp
@@ -372,7 +372,7 @@ bool UDlgHumanReadableTextCommandlet::ImportHumanReadableFormatIntoDialogue(cons
 		UDlgNode* Node = nullptr;
 		if (bIsRootNode)
 		{
-			TArray<UDlgNode*>& StartNodes = Dialogue->GetMutableStartNodes();
+			const TArray<UDlgNode*>& StartNodes = Dialogue->GetStartNodes();
 			Node = StartNodes.IsValidIndex(StartNodeIndex) ? StartNodes[StartNodeIndex] : nullptr;
 		}
 		else

--- a/Source/DlgSystemEditor/Commandlets/DlgHumanReadableTextCommandlet.h
+++ b/Source/DlgSystemEditor/Commandlets/DlgHumanReadableTextCommandlet.h
@@ -93,7 +93,7 @@ public:
 public:
 	// Metadata
 	UPROPERTY()
-	int32 NodeIndex = INDEX_NONE - 1;
+	int32 NodeIndex = MIN_int32;
 
 	UPROPERTY()
 	FName Speaker;
@@ -114,12 +114,12 @@ struct FDlgNodeSpeech_FormatHumanReadable
 
 public:
 	// INDEX_NONE is root node
-	bool IsValid() const { return NodeIndex >= INDEX_NONE; }
+	bool IsValid() const { return NodeIndex != MIN_int32; }
 
 public:
 	// Metadata, NodeIndex
 	UPROPERTY()
-	int32 NodeIndex = INDEX_NONE - 1;
+	int32 NodeIndex = MIN_int32;
 
 	UPROPERTY()
 	FName Speaker;

--- a/Source/DlgSystemEditor/DlgCommands.cpp
+++ b/Source/DlgSystemEditor/DlgCommands.cpp
@@ -136,6 +136,20 @@ void FDlgCommands::RegisterCommands()
 	);
 
 	UI_COMMAND(
+		ImportDialogueJSON,
+		"Import JSON...",
+		"Import dialogue data from a JSON file",
+		EUserInterfaceActionType::Button, FInputChord()
+	);
+
+	UI_COMMAND(
+		ExportDialogueJSON,
+		"Export JSON...",
+		"Export dialogue data to a JSON file",
+		EUserInterfaceActionType::Button, FInputChord()
+	);
+
+	UI_COMMAND(
 		HideNodes,
 		"HideNodes",
 		"Hide selected nodes",

--- a/Source/DlgSystemEditor/DlgCommands.h
+++ b/Source/DlgSystemEditor/DlgCommands.h
@@ -71,6 +71,12 @@ public:
 	// Open find in current Dialogue tab
 	TSharedPtr<FUICommandInfo> FindInDialogue;
 
+	// Import dialogue from JSON
+	TSharedPtr<FUICommandInfo> ImportDialogueJSON;
+
+	// Export dialogue to JSON
+	TSharedPtr<FUICommandInfo> ExportDialogueJSON;
+
 	// Hide Selected Node
 	TSharedPtr<FUICommandInfo> HideNodes;
 

--- a/Source/DlgSystemEditor/DlgSystemEditor.Build.cs
+++ b/Source/DlgSystemEditor/DlgSystemEditor.Build.cs
@@ -70,6 +70,7 @@ public class DlgSystemEditor : ModuleRules
 
 				// e.g. FPlatformApplicationMisc::ClipboardCopy
 				"ApplicationCore",
+				"DesktopPlatform",
 			});
 
 #if UE_4_24_OR_LATER

--- a/Source/DlgSystemEditor/Editor/DlgEditor.cpp
+++ b/Source/DlgSystemEditor/Editor/DlgEditor.cpp
@@ -32,6 +32,9 @@
 #include "DlgSystemEditor/Search/DlgSearchManager.h"
 #include "DlgSystemEditor/Search/SDlgFindInDialogues.h"
 #include "Graph/SchemaActions/DlgConvertSpeechNodesToSpeechSequence_GraphSchemaAction.h"
+#include "DlgSystemEditor/IO/DlgJsonDialogueHelper.h"
+#include "DesktopPlatformModule.h"
+#include "IDesktopPlatform.h"
 
 #define LOCTEXT_NAMESPACE "DialogueEditor"
 
@@ -668,6 +671,18 @@ void FDlgEditor::BindEditorCommands()
 		FExecuteAction::CreateLambda([this] { SummonSearchUI(true); })
 	);
 
+	// Import JSON
+	ToolkitCommands->MapAction(
+		FDlgCommands::Get().ImportDialogueJSON,
+		FExecuteAction::CreateSP(this, &Self::OnCommandImportDialogueJSON)
+	);
+
+	// Export JSON
+	ToolkitCommands->MapAction(
+		FDlgCommands::Get().ExportDialogueJSON,
+		FExecuteAction::CreateSP(this, &Self::OnCommandExportDialogueJSON)
+	);
+
 	// Map the global actions
 	FDlgSystemEditorModule::MapActionsForFileMenuExtender(ToolkitCommands);
 	FDlgSystemEditorModule::MapActionsForHelpMenuExtender(ToolkitCommands);
@@ -783,6 +798,8 @@ void FDlgEditor::ExtendToolbar()
 					);
 
 					ToolbarBuilder.AddToolBarButton(FDlgCommands::Get().ToggleShowEventsAndConditions);
+					ToolbarBuilder.AddToolBarButton(FDlgCommands::Get().ImportDialogueJSON);
+					ToolbarBuilder.AddToolBarButton(FDlgCommands::Get().ExportDialogueJSON);
 				}
 				ToolbarBuilder.EndSection();
 			})
@@ -1456,5 +1473,127 @@ void FDlgEditor::UpdateNodesHighlightedByProxy(const TSet<UObject*>& NewSelectio
 
 // End of own functions
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void FDlgEditor::OnCommandImportDialogueJSON()
+{
+	check(DialogueBeingEdited);
+
+	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+	if (!DesktopPlatform)
+	{
+		return;
+	}
+
+	TArray<FString> OpenFilenames;
+	const bool bOpened = DesktopPlatform->OpenFileDialog(
+		FSlateApplication::Get().FindBestParentWindowHandleForDialogs(nullptr),
+		LOCTEXT("ImportDialogueJSON_Title", "Import Dialogue JSON").ToString(),
+		FPaths::ProjectDir(),
+		TEXT(""),
+		TEXT("Dialogue JSON (*.dlg_human.json)|*.dlg_human.json"),
+		EFileDialogFlags::None,
+		OpenFilenames
+	);
+
+	if (!bOpened || OpenFilenames.Num() == 0)
+	{
+		return;
+	}
+
+	const FString& FilePath = OpenFilenames[0];
+	FString ErrorMessage;
+	
+	// Try regular import first (updates existing nodes only)
+	if (FDlgJsonDialogueHelper::ImportDialogueFromJsonFile(FilePath, DialogueBeingEdited, &ErrorMessage))
+	{
+		Refresh(false);
+		FPlatformMisc::MessageBoxExt(EAppMsgType::Ok,
+			*FString::Printf(TEXT("Successfully imported dialogue from:\n%s"), *FilePath),
+			TEXT("Import Successful"));
+		return;
+	}
+	
+	// Regular import failed - offer destructive import with WARNING
+	const EAppReturnType::Type WarningResult = FPlatformMisc::MessageBoxExt(EAppMsgType::YesNo,
+		*FString::Printf(
+			TEXT("WARNING!\n\n"
+				 "Import failed with error:\n%s\n\n"
+				 "The dialogue structure does not match the JSON file.\n\n"
+				 "Do you want to DESTRUCTIVELY OVERWRITE the dialogue?\n"
+				 "This will DELETE all existing nodes and recreate them from the JSON file.\n\n"
+				 "File: %s"),
+			*ErrorMessage, *FilePath),
+		TEXT("WARNING! Destructive Import"));
+	
+	if (WarningResult == EAppReturnType::Yes)
+	{
+		FString DestructiveError;
+		if (FDlgJsonDialogueHelper::ImportDialogueFromJsonFileDestructive(FilePath, DialogueBeingEdited, &DestructiveError))
+		{
+			Refresh(false);
+			FPlatformMisc::MessageBoxExt(EAppMsgType::Ok,
+				*FString::Printf(TEXT("Successfully imported dialogue (destructive) from:\n%s"), *FilePath),
+				TEXT("Import Successful"));
+		}
+		else
+		{
+			FPlatformMisc::MessageBoxExt(EAppMsgType::Ok,
+				*FString::Printf(TEXT("Destructive import failed:\n%s"), *DestructiveError),
+				TEXT("Import Failed"));
+		}
+	}
+}
+
+void FDlgEditor::OnCommandExportDialogueJSON()
+{
+	check(DialogueBeingEdited);
+
+	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+	if (!DesktopPlatform)
+	{
+		return;
+	}
+
+	FString SaveFilename = DialogueBeingEdited->GetDialogueFName().ToString() + TEXT(".dlg_human.json");
+	TArray<FString> SavePaths;
+	const bool bSaved = DesktopPlatform->SaveFileDialog(
+		FSlateApplication::Get().FindBestParentWindowHandleForDialogs(nullptr),
+		LOCTEXT("ExportDialogueJSON_Title", "Export Dialogue JSON").ToString(),
+		FPaths::ProjectDir(),
+		*SaveFilename,
+		TEXT("Dialogue JSON (*.dlg_human.json)|*.dlg_human.json"),
+		EFileDialogFlags::None,
+		SavePaths
+	);
+
+	if (!bSaved || SavePaths.Num() == 0)
+	{
+		return;
+	}
+
+	const FString& SavePath = SavePaths[0];
+	FString JsonString;
+	if (FDlgJsonDialogueHelper::ExportDialogueToJson(DialogueBeingEdited, JsonString))
+	{
+		if (FFileHelper::SaveStringToFile(JsonString, *SavePath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+		{
+			FPlatformMisc::MessageBoxExt(EAppMsgType::Ok,
+				*FString::Printf(TEXT("Successfully exported dialogue to:\n%s"), *SavePath),
+				TEXT("Export Successful"));
+		}
+		else
+		{
+			FPlatformMisc::MessageBoxExt(EAppMsgType::Ok,
+				*FString::Printf(TEXT("Failed to write file:\n%s"), *SavePath),
+				TEXT("Export Failed"));
+		}
+	}
+	else
+	{
+		FPlatformMisc::MessageBoxExt(EAppMsgType::Ok,
+			TEXT("Failed to serialize dialogue to JSON."),
+			TEXT("Export Failed"));
+	}
+}
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/DlgSystemEditor/Editor/DlgEditor.cpp
+++ b/Source/DlgSystemEditor/Editor/DlgEditor.cpp
@@ -1503,8 +1503,8 @@ void FDlgEditor::OnCommandImportDialogueJSON()
 	const FString& FilePath = OpenFilenames[0];
 	FString ErrorMessage;
 	
-	// Try regular import first (updates existing nodes only)
-	if (FDlgJsonDialogueHelper::ImportDialogueFromJsonFile(FilePath, DialogueBeingEdited, &ErrorMessage))
+	// Try updating matching existing nodes before offering to replace the whole dialogue.
+	if (FDlgJsonDialogueHelper::ImportDialogueNodeUpdatesFromJsonFile(FilePath, DialogueBeingEdited, &ErrorMessage))
 	{
 		Refresh(false);
 		FPlatformMisc::MessageBoxExt(EAppMsgType::Ok,
@@ -1528,7 +1528,7 @@ void FDlgEditor::OnCommandImportDialogueJSON()
 	if (WarningResult == EAppReturnType::Yes)
 	{
 		FString DestructiveError;
-		if (FDlgJsonDialogueHelper::ImportDialogueFromJsonFileDestructive(FilePath, DialogueBeingEdited, &DestructiveError))
+		if (FDlgJsonDialogueHelper::ImportDialogueFromJsonFileAsReplacement(FilePath, DialogueBeingEdited, &DestructiveError))
 		{
 			Refresh(false);
 			FPlatformMisc::MessageBoxExt(EAppMsgType::Ok,

--- a/Source/DlgSystemEditor/Editor/DlgEditor.h
+++ b/Source/DlgSystemEditor/Editor/DlgEditor.h
@@ -271,6 +271,12 @@ private:
 	// Reloads the Dialogue from the file
 	void OnCommandDialogueReload() const;
 
+	// Imports the Dialogue from a JSON file
+	void OnCommandImportDialogueJSON();
+
+	// Exports the Dialogue to a JSON file
+	void OnCommandExportDialogueJSON();
+
 	//
 	// Graph events
 	//

--- a/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
+++ b/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
@@ -102,23 +102,11 @@ bool FDlgJsonDialogueHelper::ImportDialogueFromJsonDestructive(const FString& Js
 		return false;
 	}
 
-	FDlgJsonParser JsonParser;
-	JsonParser.InitializeParserFromString(JsonString);
-	if (!JsonParser.IsValidFile())
+	if (OutError)
 	{
-		if (OutError) *OutError = TEXT("Invalid JSON format");
-		return false;
+		*OutError = TEXT("Destructive JSON import is unsupported because the JSON format does not preserve every dialogue node type and node-specific property.");
 	}
-
-	FDlgDialogue_FormatHumanReadable HumanFormat;
-	JsonParser.ReadAllProperty(FDlgDialogue_FormatHumanReadable::StaticStruct(), &HumanFormat);
-	if (!JsonParser.IsValidFile())
-	{
-		if (OutError) *OutError = TEXT("Failed to parse dialogue format from JSON");
-		return false;
-	}
-
-	return ImportHumanReadableFormatIntoDialogueDestructive(HumanFormat, Dialogue, OutError);
+	return false;
 }
 
 bool FDlgJsonDialogueHelper::ImportDialogueFromJsonFileDestructive(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError)
@@ -134,23 +122,11 @@ bool FDlgJsonDialogueHelper::ImportDialogueFromJsonFileDestructive(const FString
 		return false;
 	}
 
-	FDlgJsonParser JsonParser;
-	JsonParser.InitializeParser(FilePath);
-	if (!JsonParser.IsValidFile())
+	if (OutError)
 	{
-		if (OutError) *OutError = FString::Printf(TEXT("Failed to read/parse JSON file: %s"), *FilePath);
-		return false;
+		*OutError = TEXT("Destructive JSON import is unsupported because the JSON format does not preserve every dialogue node type and node-specific property.");
 	}
-
-	FDlgDialogue_FormatHumanReadable HumanFormat;
-	JsonParser.ReadAllProperty(FDlgDialogue_FormatHumanReadable::StaticStruct(), &HumanFormat);
-	if (!JsonParser.IsValidFile())
-	{
-		if (OutError) *OutError = TEXT("Failed to parse dialogue format from JSON file");
-		return false;
-	}
-
-	return ImportHumanReadableFormatIntoDialogueDestructive(HumanFormat, Dialogue, OutError);
+	return false;
 }
 
 bool FDlgJsonDialogueHelper::ExportDialogueToHumanReadableFormat(const UDlgDialogue& Dialogue, FDlgDialogue_FormatHumanReadable& OutFormat)
@@ -158,7 +134,7 @@ bool FDlgJsonDialogueHelper::ExportDialogueToHumanReadableFormat(const UDlgDialo
 	OutFormat.DialogueName = Dialogue.GetDialogueFName();
 	OutFormat.DialogueGUID = Dialogue.GetGUID();
 
-	// Root Nodes
+	// Start nodes are exported as pseudo speech nodes with negative indices: -1, -2, -3, etc.
 	const TArray<UDlgNode*> StartNodes = Dialogue.GetStartNodes();
 	for (int32 i = 0; i < StartNodes.Num(); ++i)
 	{
@@ -199,8 +175,8 @@ bool FDlgJsonDialogueHelper::ExportDialogueToHumanReadableFormat(const UDlgDialo
 		}
 		else
 		{
-			// Other node types (End, Start, Proxy, Selector, Custom, etc.)
-			// Export as empty speech node so edges are preserved
+			// Unsupported node classes are represented only by their index and edges.
+			// This is enough for non-destructive edge-text import, but not for recreating nodes.
 			FDlgNodeSpeech_FormatHumanReadable ExportNode;
 			ExportNode.NodeIndex = NodeIndex;
 			ExportNode.Speaker = NAME_None;
@@ -249,30 +225,34 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		return false;
 	}
 
-	// Speech nodes
+	// Speech nodes and exported start-node pseudo nodes.
 	for (const FDlgNodeSpeech_FormatHumanReadable& HumanNode : Format.SpeechNodes)
 	{
-		if (!HumanNode.IsValid())
+		const bool bIsRootNode = HumanNode.NodeIndex <= RootNodeIndex;
+		if (!bIsRootNode && !HumanNode.IsValid())
 		{
 			SkippedNodes++;
 			continue;
 		}
 
-		const bool bIsRootNode = HumanNode.NodeIndex <= RootNodeIndex;
-		UDlgNode* Node = bIsRootNode
-			? Dialogue->GetMutableStartNodes()[FMath::Abs(RootNodeIndex) - 1]
-			: Dialogue->GetMutableNodeFromIndex(HumanNode.NodeIndex);
+		UDlgNode* Node = nullptr;
+		if (bIsRootNode)
+		{
+			const int32 StartNodeIndex = -HumanNode.NodeIndex - 1;
+			TArray<UDlgNode*>& StartNodes = Dialogue->GetMutableStartNodes();
+			Node = StartNodes.IsValidIndex(StartNodeIndex) ? StartNodes[StartNodeIndex] : nullptr;
+		}
+		else
+		{
+			Node = Dialogue->GetMutableNodeFromIndex(HumanNode.NodeIndex);
+		}
 
 		if (Node == nullptr)
 		{
-			if (!bIsRootNode)
+			MismatchedNodes++;
+			if (OutError && OutError->IsEmpty())
 			{
-				MismatchedNodes++;
-				if (OutError && OutError->IsEmpty())
-				{
-					*OutError = FString::Printf(TEXT("Node index %d from JSON not found in dialogue (dialogue has %d nodes)"),
-						HumanNode.NodeIndex, Dialogue->GetNodes().Num());
-				}
+				*OutError = FString::Printf(TEXT("Node index %d from JSON not found in dialogue."), HumanNode.NodeIndex);
 			}
 			continue;
 		}
@@ -294,27 +274,22 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 					bModified = true;
 				}
 			}
-			else
-			{
-				// Node exists but is not a speech node (e.g. End node) - that's ok, just skip text update
-			}
 		}
 
 		UDialogueGraphNode* GraphNode = Cast<UDialogueGraphNode>(Node->GetGraphNode());
-		if (GraphNode == nullptr)
+		if (GraphNode != nullptr)
 		{
-			continue;
+			if (SetGraphNodesNewEdgesText(GraphNode, HumanNode.Edges, HumanNode.NodeIndex, Dialogue))
+			{
+				bModified = true;
+			}
+			GraphNode->CheckAll();
 		}
 
-		if (SetGraphNodesNewEdgesText(GraphNode, HumanNode.Edges, HumanNode.NodeIndex, Dialogue))
-		{
-			bModified = true;
-		}
-		GraphNode->CheckAll();
 		ProcessedNodes++;
 	}
 
-	// Speech sequence nodes
+	// Speech sequence nodes.
 	for (const FDlgNodeSpeechSequence_FormatHumanReadable& HumanSpeechSequence : Format.SpeechSequenceNodes)
 	{
 		if (!HumanSpeechSequence.IsValid())
@@ -377,16 +352,15 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		}
 
 		UDialogueGraphNode* GraphNode = Cast<UDialogueGraphNode>(Node->GetGraphNode());
-		if (GraphNode == nullptr)
+		if (GraphNode != nullptr)
 		{
-			continue;
+			if (SetGraphNodesNewEdgesText(GraphNode, HumanSpeechSequence.Edges, HumanSpeechSequence.NodeIndex, Dialogue))
+			{
+				bModified = true;
+			}
+			GraphNode->CheckAll();
 		}
 
-		if (SetGraphNodesNewEdgesText(GraphNode, HumanSpeechSequence.Edges, HumanSpeechSequence.NodeIndex, Dialogue))
-		{
-			bModified = true;
-		}
-		GraphNode->CheckAll();
 		ProcessedNodes++;
 	}
 
@@ -396,151 +370,29 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		Dialogue->MarkPackageDirty();
 	}
 
-	if (!bModified && OutError && OutError->IsEmpty())
+	if (ProcessedNodes == 0)
 	{
-		if (MismatchedNodes > 0)
+		if (OutError && OutError->IsEmpty())
 		{
-			*OutError = FString::Printf(TEXT("Import completed but no changes were made. %d node(s) from JSON did not match the dialogue structure. The dialogue may have a different node count or node types than the JSON file."), MismatchedNodes);
+			*OutError = SkippedNodes > 0
+				? TEXT("Import completed but no nodes were processed. All JSON nodes were invalid or incompatible.")
+				: TEXT("Import completed but no nodes were processed.");
 		}
-		else if (ProcessedNodes == 0)
-		{
-			*OutError = TEXT("Import completed but no nodes were processed. The JSON file may be empty or all nodes were invalid.");
-		}
-		else
-		{
-			*OutError = TEXT("Import completed but no changes were needed. All text/speaker/edge data already matches.");
-		}
-	}
-
-	return bModified;
-}
-
-bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogueDestructive(
-	const FDlgDialogue_FormatHumanReadable& Format, UDlgDialogue* Dialogue, FString* OutError)
-{
-	verify(Dialogue);
-
-	if (Format.SpeechNodes.Num() == 0 && Format.SpeechSequenceNodes.Num() == 0)
-	{
-		if (OutError) *OutError = TEXT("No speech nodes or speech sequence nodes found in JSON");
 		return false;
 	}
 
-	// Clear existing graph and dialogue data
-	// IMPORTANT: Clear graph first to remove stale graph node references
-	if (Dialogue->GetGraph())
+	if (OutError && OutError->IsEmpty())
 	{
-		Dialogue->ClearGraph();
-	}
-	Dialogue->SetStartNodes(TArray<UDlgNode*>());
-	Dialogue->SetNodes(TArray<UDlgNode*>());
-
-	// Maps JSON node index -> created UDlgNode*
-	TMap<int32, UDlgNode*> CreatedNodes;
-	TMap<int32, TArray<FDlgEdge_FormatHumanReadable>> NodeEdges;
-
-	// First pass: create all nodes
-	for (const FDlgNodeSpeech_FormatHumanReadable& HumanNode : Format.SpeechNodes)
-	{
-		if (!HumanNode.IsValid())
+		if (MismatchedNodes > 0)
 		{
-			continue;
+			*OutError = FString::Printf(TEXT("Import completed with %d unmatched node(s). Matching nodes were processed."), MismatchedNodes);
 		}
-
-		const bool bIsRootNode = HumanNode.NodeIndex <= RootNodeIndex;
-		if (bIsRootNode)
+		else if (!bModified)
 		{
-			// Create start node
-			UDlgNode_Start* StartNode = Dialogue->ConstructDialogueNode<UDlgNode_Start>();
-			Dialogue->AddStartNode(StartNode);
-			CreatedNodes.Add(HumanNode.NodeIndex, StartNode);
-			NodeEdges.Add(HumanNode.NodeIndex, HumanNode.Edges);
-		}
-		else
-		{
-			// Create speech node
-			UDlgNode_Speech* SpeechNode = Dialogue->ConstructDialogueNode<UDlgNode_Speech>();
-			SpeechNode->SetNodeParticipantName(HumanNode.Speaker);
-			SpeechNode->SetNodeText(HumanNode.Text);
-			Dialogue->AddNode(SpeechNode);
-			CreatedNodes.Add(HumanNode.NodeIndex, SpeechNode);
-			NodeEdges.Add(HumanNode.NodeIndex, HumanNode.Edges);
+			*OutError = TEXT("Import completed successfully. No changes were needed because the dialogue already matched the JSON.");
 		}
 	}
 
-	for (const FDlgNodeSpeechSequence_FormatHumanReadable& HumanSpeechSequence : Format.SpeechSequenceNodes)
-	{
-		if (!HumanSpeechSequence.IsValid())
-		{
-			continue;
-		}
-
-		UDlgNode_SpeechSequence* SequenceNode = Dialogue->ConstructDialogueNode<UDlgNode_SpeechSequence>();
-		SequenceNode->SetNodeParticipantName(HumanSpeechSequence.Speaker);
-		
-		TArray<FDlgSpeechSequenceEntry>& SequenceArray = *SequenceNode->GetMutableNodeSpeechSequence();
-		SequenceArray.Empty();
-		for (const FDlgSpeechSequenceEntry_FormatHumanReadable& HumanSequence : HumanSpeechSequence.Sequence)
-		{
-			FDlgSpeechSequenceEntry Entry;
-			Entry.EdgeText = HumanSequence.EdgeText;
-			Entry.Text = HumanSequence.Text;
-			Entry.Speaker = HumanSequence.Speaker;
-			SequenceArray.Add(Entry);
-		}
-		
-		Dialogue->AddNode(SequenceNode);
-		CreatedNodes.Add(HumanSpeechSequence.NodeIndex, SequenceNode);
-		NodeEdges.Add(HumanSpeechSequence.NodeIndex, HumanSpeechSequence.Edges);
-	}
-
-	// Second pass: wire up edges
-	for (const auto& Pair : NodeEdges)
-	{
-		const int32 SourceIndex = Pair.Key;
-		const TArray<FDlgEdge_FormatHumanReadable>& Edges = Pair.Value;
-		
-		UDlgNode** SourceNodePtr = CreatedNodes.Find(SourceIndex);
-		if (!SourceNodePtr || !*SourceNodePtr)
-		{
-			continue;
-		}
-		
-		UDlgNode* SourceNode = *SourceNodePtr;
-		for (const FDlgEdge_FormatHumanReadable& HumanEdge : Edges)
-		{
-			UDlgNode** TargetNodePtr = CreatedNodes.Find(HumanEdge.TargetNodeIndex);
-			if (!TargetNodePtr || !*TargetNodePtr)
-			{
-				// Target node doesn't exist - create an End node as fallback
-				UDlgNode_End* EndNode = Dialogue->ConstructDialogueNode<UDlgNode_End>();
-				Dialogue->AddNode(EndNode);
-				CreatedNodes.Add(HumanEdge.TargetNodeIndex, EndNode);
-				TargetNodePtr = CreatedNodes.Find(HumanEdge.TargetNodeIndex);
-			}
-			
-			if (TargetNodePtr && *TargetNodePtr)
-			{
-				FDlgEdge Edge;
-				Edge.TargetIndex = HumanEdge.TargetNodeIndex;
-				Edge.SetText(HumanEdge.Text);
-				SourceNode->AddNodeChild(Edge);
-			}
-		}
-	}
-
-	Dialogue->Modify();
-	Dialogue->MarkPackageDirty();
-	
-	// Rebuild the graph from the new dialogue nodes
-	if (UDialogueGraph* DialogueGraph = Cast<UDialogueGraph>(Dialogue->GetGraph()))
-	{
-		DialogueGraph->RemoveAllNodes();
-		DialogueGraph->CreateGraphNodesFromDialogue();
-		DialogueGraph->LinkGraphNodesFromDialogue();
-		DialogueGraph->AutoPositionGraphNodes();
-	}
-	
 	return true;
 }
 

--- a/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
+++ b/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
@@ -261,7 +261,7 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		UDlgNode* Node = nullptr;
 		if (bIsRootNode)
 		{
-			TArray<UDlgNode*>& StartNodes = Dialogue->GetMutableStartNodes();
+			const TArray<UDlgNode*>& StartNodes = Dialogue->GetStartNodes();
 			Node = StartNodes.IsValidIndex(StartNodeIndex) ? StartNodes[StartNodeIndex] : nullptr;
 		}
 		else

--- a/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
+++ b/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
@@ -1,0 +1,567 @@
+// Copyright Csaba Molnar, Daniel Butum. All Rights Reserved.
+#include "DlgJsonDialogueHelper.h"
+
+#include "DlgSystem/IO/DlgJsonWriter.h"
+#include "DlgSystem/IO/DlgJsonParser.h"
+#include "DlgSystem/DlgHelper.h"
+#include "DlgSystem/Nodes/DlgNode_Start.h"
+
+bool FDlgJsonDialogueHelper::ExportDialogueToJson(const UDlgDialogue* Dialogue, FString& OutJsonString)
+{
+	if (!IsValid(Dialogue))
+	{
+		return false;
+	}
+
+	FDlgDialogue_FormatHumanReadable ExportFormat;
+	if (!ExportDialogueToHumanReadableFormat(*Dialogue, ExportFormat))
+	{
+		return false;
+	}
+
+	FDlgJsonWriter JsonWriter;
+	JsonWriter.Write(FDlgDialogue_FormatHumanReadable::StaticStruct(), &ExportFormat);
+	OutJsonString = JsonWriter.GetAsString();
+	return !OutJsonString.IsEmpty();
+}
+
+bool FDlgJsonDialogueHelper::ImportDialogueFromJson(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError)
+{
+	if (!IsValid(Dialogue))
+	{
+		if (OutError) *OutError = TEXT("Invalid dialogue asset");
+		return false;
+	}
+	if (JsonString.IsEmpty())
+	{
+		if (OutError) *OutError = TEXT("Empty JSON string");
+		return false;
+	}
+
+	FDlgJsonParser JsonParser;
+	JsonParser.InitializeParserFromString(JsonString);
+	if (!JsonParser.IsValidFile())
+	{
+		if (OutError) *OutError = TEXT("Invalid JSON format");
+		return false;
+	}
+
+	FDlgDialogue_FormatHumanReadable HumanFormat;
+	JsonParser.ReadAllProperty(FDlgDialogue_FormatHumanReadable::StaticStruct(), &HumanFormat);
+	if (!JsonParser.IsValidFile())
+	{
+		if (OutError) *OutError = TEXT("Failed to parse dialogue format from JSON");
+		return false;
+	}
+
+	return ImportHumanReadableFormatIntoDialogue(HumanFormat, Dialogue, OutError);
+}
+
+bool FDlgJsonDialogueHelper::ImportDialogueFromJsonFile(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError)
+{
+	if (!IsValid(Dialogue))
+	{
+		if (OutError) *OutError = TEXT("Invalid dialogue asset");
+		return false;
+	}
+	if (FilePath.IsEmpty())
+	{
+		if (OutError) *OutError = TEXT("Empty file path");
+		return false;
+	}
+
+	FDlgJsonParser JsonParser;
+	JsonParser.InitializeParser(FilePath);
+	if (!JsonParser.IsValidFile())
+	{
+		if (OutError) *OutError = FString::Printf(TEXT("Failed to read/parse JSON file: %s"), *FilePath);
+		return false;
+	}
+
+	FDlgDialogue_FormatHumanReadable HumanFormat;
+	JsonParser.ReadAllProperty(FDlgDialogue_FormatHumanReadable::StaticStruct(), &HumanFormat);
+	if (!JsonParser.IsValidFile())
+	{
+		if (OutError) *OutError = TEXT("Failed to parse dialogue format from JSON file");
+		return false;
+	}
+
+	return ImportHumanReadableFormatIntoDialogue(HumanFormat, Dialogue, OutError);
+}
+
+bool FDlgJsonDialogueHelper::ImportDialogueFromJsonDestructive(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError)
+{
+	if (!IsValid(Dialogue))
+	{
+		if (OutError) *OutError = TEXT("Invalid dialogue asset");
+		return false;
+	}
+	if (JsonString.IsEmpty())
+	{
+		if (OutError) *OutError = TEXT("Empty JSON string");
+		return false;
+	}
+
+	FDlgJsonParser JsonParser;
+	JsonParser.InitializeParserFromString(JsonString);
+	if (!JsonParser.IsValidFile())
+	{
+		if (OutError) *OutError = TEXT("Invalid JSON format");
+		return false;
+	}
+
+	FDlgDialogue_FormatHumanReadable HumanFormat;
+	JsonParser.ReadAllProperty(FDlgDialogue_FormatHumanReadable::StaticStruct(), &HumanFormat);
+	if (!JsonParser.IsValidFile())
+	{
+		if (OutError) *OutError = TEXT("Failed to parse dialogue format from JSON");
+		return false;
+	}
+
+	return ImportHumanReadableFormatIntoDialogueDestructive(HumanFormat, Dialogue, OutError);
+}
+
+bool FDlgJsonDialogueHelper::ImportDialogueFromJsonFileDestructive(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError)
+{
+	if (!IsValid(Dialogue))
+	{
+		if (OutError) *OutError = TEXT("Invalid dialogue asset");
+		return false;
+	}
+	if (FilePath.IsEmpty())
+	{
+		if (OutError) *OutError = TEXT("Empty file path");
+		return false;
+	}
+
+	FDlgJsonParser JsonParser;
+	JsonParser.InitializeParser(FilePath);
+	if (!JsonParser.IsValidFile())
+	{
+		if (OutError) *OutError = FString::Printf(TEXT("Failed to read/parse JSON file: %s"), *FilePath);
+		return false;
+	}
+
+	FDlgDialogue_FormatHumanReadable HumanFormat;
+	JsonParser.ReadAllProperty(FDlgDialogue_FormatHumanReadable::StaticStruct(), &HumanFormat);
+	if (!JsonParser.IsValidFile())
+	{
+		if (OutError) *OutError = TEXT("Failed to parse dialogue format from JSON file");
+		return false;
+	}
+
+	return ImportHumanReadableFormatIntoDialogueDestructive(HumanFormat, Dialogue, OutError);
+}
+
+bool FDlgJsonDialogueHelper::ExportDialogueToHumanReadableFormat(const UDlgDialogue& Dialogue, FDlgDialogue_FormatHumanReadable& OutFormat)
+{
+	OutFormat.DialogueName = Dialogue.GetDialogueFName();
+	OutFormat.DialogueGUID = Dialogue.GetGUID();
+
+	// Root Nodes
+	const TArray<UDlgNode*> StartNodes = Dialogue.GetStartNodes();
+	for (int32 i = 0; i < StartNodes.Num(); ++i)
+	{
+		FDlgNodeSpeech_FormatHumanReadable RootNode;
+		RootNode.NodeIndex = RootNodeIndex * (i + 1);
+		ExportNodeEdgesToHumanReadableFormat(StartNodes[i]->GetNodeChildren(), RootNode.Edges);
+		OutFormat.SpeechNodes.Add(RootNode);
+	}
+
+	const TArray<UDlgNode*>& Nodes = Dialogue.GetNodes();
+	for (int32 NodeIndex = 0; NodeIndex < Nodes.Num(); NodeIndex++)
+	{
+		const UDlgNode* Node = Nodes[NodeIndex];
+		if (const UDlgNode_Speech* NodeSpeech = Cast<UDlgNode_Speech>(Node))
+		{
+			FDlgNodeSpeech_FormatHumanReadable ExportNode;
+			ExportNode.NodeIndex = NodeIndex;
+			ExportNode.Speaker = NodeSpeech->GetNodeParticipantName();
+			ExportNode.Text = NodeSpeech->GetNodeUnformattedText();
+			ExportNodeEdgesToHumanReadableFormat(Node->GetNodeChildren(), ExportNode.Edges);
+			OutFormat.SpeechNodes.Add(ExportNode);
+		}
+		else if (const UDlgNode_SpeechSequence* NodeSpeechSequence = Cast<UDlgNode_SpeechSequence>(Node))
+		{
+			FDlgNodeSpeechSequence_FormatHumanReadable ExportNode;
+			ExportNode.NodeIndex = NodeIndex;
+			ExportNode.Speaker = NodeSpeechSequence->GetNodeParticipantName();
+			for (const FDlgSpeechSequenceEntry& Entry : NodeSpeechSequence->GetNodeSpeechSequence())
+			{
+				FDlgSpeechSequenceEntry_FormatHumanReadable ExportEntry;
+				ExportEntry.EdgeText = Entry.EdgeText;
+				ExportEntry.Text = Entry.Text;
+				ExportEntry.Speaker = Entry.Speaker;
+				ExportNode.Sequence.Add(ExportEntry);
+			}
+			ExportNodeEdgesToHumanReadableFormat(Node->GetNodeChildren(), ExportNode.Edges);
+			OutFormat.SpeechSequenceNodes.Add(ExportNode);
+		}
+		else
+		{
+			// Other node types (End, Start, Proxy, Selector, Custom, etc.)
+			// Export as empty speech node so edges are preserved
+			FDlgNodeSpeech_FormatHumanReadable ExportNode;
+			ExportNode.NodeIndex = NodeIndex;
+			ExportNode.Speaker = NAME_None;
+			ExportNode.Text = FText::GetEmpty();
+			ExportNodeEdgesToHumanReadableFormat(Node->GetNodeChildren(), ExportNode.Edges);
+			OutFormat.SpeechNodes.Add(ExportNode);
+		}
+
+		if (const UDialogueGraphNode_Base* GraphNode = Cast<UDialogueGraphNode_Base>(Node->GetGraphNode()))
+		{
+			GraphNode->CheckAll();
+		}
+	}
+
+	return true;
+}
+
+void FDlgJsonDialogueHelper::ExportNodeEdgesToHumanReadableFormat(const TArray<FDlgEdge>& Edges, TArray<FDlgEdge_FormatHumanReadable>& OutEdges)
+{
+	for (const FDlgEdge& Edge : Edges)
+	{
+		if (!Edge.IsValid())
+		{
+			continue;
+		}
+
+		FDlgEdge_FormatHumanReadable ExportEdge;
+		ExportEdge.TargetNodeIndex = Edge.TargetIndex;
+		ExportEdge.Text = Edge.GetUnformattedText();
+		OutEdges.Add(ExportEdge);
+	}
+}
+
+bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDialogue_FormatHumanReadable& Format, UDlgDialogue* Dialogue, FString* OutError)
+{
+	verify(Dialogue);
+
+	bool bModified = false;
+	int32 ProcessedNodes = 0;
+	int32 SkippedNodes = 0;
+	int32 MismatchedNodes = 0;
+
+	if (Format.SpeechNodes.Num() == 0 && Format.SpeechSequenceNodes.Num() == 0)
+	{
+		if (OutError) *OutError = TEXT("No speech nodes or speech sequence nodes found in JSON");
+		return false;
+	}
+
+	// Speech nodes
+	for (const FDlgNodeSpeech_FormatHumanReadable& HumanNode : Format.SpeechNodes)
+	{
+		if (!HumanNode.IsValid())
+		{
+			SkippedNodes++;
+			continue;
+		}
+
+		const bool bIsRootNode = HumanNode.NodeIndex <= RootNodeIndex;
+		UDlgNode* Node = bIsRootNode
+			? Dialogue->GetMutableStartNodes()[FMath::Abs(RootNodeIndex) - 1]
+			: Dialogue->GetMutableNodeFromIndex(HumanNode.NodeIndex);
+
+		if (Node == nullptr)
+		{
+			if (!bIsRootNode)
+			{
+				MismatchedNodes++;
+				if (OutError && OutError->IsEmpty())
+				{
+					*OutError = FString::Printf(TEXT("Node index %d from JSON not found in dialogue (dialogue has %d nodes)"),
+						HumanNode.NodeIndex, Dialogue->GetNodes().Num());
+				}
+			}
+			continue;
+		}
+
+		if (!bIsRootNode)
+		{
+			UDlgNode_Speech* NodeSpeech = Cast<UDlgNode_Speech>(Node);
+			if (NodeSpeech != nullptr)
+			{
+				if (!NodeSpeech->GetNodeUnformattedText().EqualTo(HumanNode.Text))
+				{
+					NodeSpeech->SetNodeText(HumanNode.Text);
+					bModified = true;
+				}
+
+				if (!NodeSpeech->GetNodeParticipantName().IsEqual(HumanNode.Speaker, ENameCase::CaseSensitive))
+				{
+					NodeSpeech->SetNodeParticipantName(HumanNode.Speaker);
+					bModified = true;
+				}
+			}
+			else
+			{
+				// Node exists but is not a speech node (e.g. End node) - that's ok, just skip text update
+			}
+		}
+
+		UDialogueGraphNode* GraphNode = Cast<UDialogueGraphNode>(Node->GetGraphNode());
+		if (GraphNode == nullptr)
+		{
+			continue;
+		}
+
+		if (SetGraphNodesNewEdgesText(GraphNode, HumanNode.Edges, HumanNode.NodeIndex, Dialogue))
+		{
+			bModified = true;
+		}
+		GraphNode->CheckAll();
+		ProcessedNodes++;
+	}
+
+	// Speech sequence nodes
+	for (const FDlgNodeSpeechSequence_FormatHumanReadable& HumanSpeechSequence : Format.SpeechSequenceNodes)
+	{
+		if (!HumanSpeechSequence.IsValid())
+		{
+			SkippedNodes++;
+			continue;
+		}
+
+		UDlgNode* Node = Dialogue->GetMutableNodeFromIndex(HumanSpeechSequence.NodeIndex);
+		if (Node == nullptr)
+		{
+			MismatchedNodes++;
+			if (OutError && OutError->IsEmpty())
+			{
+				*OutError = FString::Printf(TEXT("Speech sequence node index %d from JSON not found in dialogue (dialogue has %d nodes)"),
+					HumanSpeechSequence.NodeIndex, Dialogue->GetNodes().Num());
+			}
+			continue;
+		}
+
+		UDlgNode_SpeechSequence* NodeSpeechSequence = Cast<UDlgNode_SpeechSequence>(Node);
+		if (NodeSpeechSequence == nullptr)
+		{
+			MismatchedNodes++;
+			if (OutError && OutError->IsEmpty())
+			{
+				*OutError = FString::Printf(TEXT("Node index %d is not a speech sequence node in the dialogue"), HumanSpeechSequence.NodeIndex);
+			}
+			continue;
+		}
+
+		if (!NodeSpeechSequence->GetNodeParticipantName().IsEqual(HumanSpeechSequence.Speaker, ENameCase::CaseSensitive))
+		{
+			NodeSpeechSequence->SetNodeParticipantName(HumanSpeechSequence.Speaker);
+			bModified = true;
+		}
+
+		TArray<FDlgSpeechSequenceEntry>& SequenceArray = *NodeSpeechSequence->GetMutableNodeSpeechSequence();
+		for (int32 SequenceIndex = 0; SequenceIndex < SequenceArray.Num() && SequenceIndex < HumanSpeechSequence.Sequence.Num(); SequenceIndex++)
+		{
+			const FDlgSpeechSequenceEntry_FormatHumanReadable& HumanSequence = HumanSpeechSequence.Sequence[SequenceIndex];
+
+			if (!SequenceArray[SequenceIndex].EdgeText.EqualTo(HumanSequence.EdgeText))
+			{
+				SequenceArray[SequenceIndex].EdgeText = HumanSequence.EdgeText;
+				bModified = true;
+			}
+
+			if (!SequenceArray[SequenceIndex].Speaker.IsEqual(HumanSequence.Speaker, ENameCase::CaseSensitive))
+			{
+				SequenceArray[SequenceIndex].Speaker = HumanSequence.Speaker;
+				bModified = true;
+			}
+
+			if (!SequenceArray[SequenceIndex].Text.EqualTo(HumanSequence.Text))
+			{
+				SequenceArray[SequenceIndex].Text = HumanSequence.Text;
+				bModified = true;
+			}
+		}
+
+		UDialogueGraphNode* GraphNode = Cast<UDialogueGraphNode>(Node->GetGraphNode());
+		if (GraphNode == nullptr)
+		{
+			continue;
+		}
+
+		if (SetGraphNodesNewEdgesText(GraphNode, HumanSpeechSequence.Edges, HumanSpeechSequence.NodeIndex, Dialogue))
+		{
+			bModified = true;
+		}
+		GraphNode->CheckAll();
+		ProcessedNodes++;
+	}
+
+	if (bModified)
+	{
+		Dialogue->Modify();
+		Dialogue->MarkPackageDirty();
+	}
+
+	if (!bModified && OutError && OutError->IsEmpty())
+	{
+		if (MismatchedNodes > 0)
+		{
+			*OutError = FString::Printf(TEXT("Import completed but no changes were made. %d node(s) from JSON did not match the dialogue structure. The dialogue may have a different node count or node types than the JSON file."), MismatchedNodes);
+		}
+		else if (ProcessedNodes == 0)
+		{
+			*OutError = TEXT("Import completed but no nodes were processed. The JSON file may be empty or all nodes were invalid.");
+		}
+		else
+		{
+			*OutError = TEXT("Import completed but no changes were needed. All text/speaker/edge data already matches.");
+		}
+	}
+
+	return bModified;
+}
+
+bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogueDestructive(
+	const FDlgDialogue_FormatHumanReadable& Format, UDlgDialogue* Dialogue, FString* OutError)
+{
+	verify(Dialogue);
+
+	if (Format.SpeechNodes.Num() == 0 && Format.SpeechSequenceNodes.Num() == 0)
+	{
+		if (OutError) *OutError = TEXT("No speech nodes or speech sequence nodes found in JSON");
+		return false;
+	}
+
+	// Clear existing graph and dialogue data
+	// IMPORTANT: Clear graph first to remove stale graph node references
+	if (Dialogue->GetGraph())
+	{
+		Dialogue->ClearGraph();
+	}
+	Dialogue->SetStartNodes(TArray<UDlgNode*>());
+	Dialogue->SetNodes(TArray<UDlgNode*>());
+
+	// Maps JSON node index -> created UDlgNode*
+	TMap<int32, UDlgNode*> CreatedNodes;
+	TMap<int32, TArray<FDlgEdge_FormatHumanReadable>> NodeEdges;
+
+	// First pass: create all nodes
+	for (const FDlgNodeSpeech_FormatHumanReadable& HumanNode : Format.SpeechNodes)
+	{
+		if (!HumanNode.IsValid())
+		{
+			continue;
+		}
+
+		const bool bIsRootNode = HumanNode.NodeIndex <= RootNodeIndex;
+		if (bIsRootNode)
+		{
+			// Create start node
+			UDlgNode_Start* StartNode = Dialogue->ConstructDialogueNode<UDlgNode_Start>();
+			Dialogue->AddStartNode(StartNode);
+			CreatedNodes.Add(HumanNode.NodeIndex, StartNode);
+			NodeEdges.Add(HumanNode.NodeIndex, HumanNode.Edges);
+		}
+		else
+		{
+			// Create speech node
+			UDlgNode_Speech* SpeechNode = Dialogue->ConstructDialogueNode<UDlgNode_Speech>();
+			SpeechNode->SetNodeParticipantName(HumanNode.Speaker);
+			SpeechNode->SetNodeText(HumanNode.Text);
+			Dialogue->AddNode(SpeechNode);
+			CreatedNodes.Add(HumanNode.NodeIndex, SpeechNode);
+			NodeEdges.Add(HumanNode.NodeIndex, HumanNode.Edges);
+		}
+	}
+
+	for (const FDlgNodeSpeechSequence_FormatHumanReadable& HumanSpeechSequence : Format.SpeechSequenceNodes)
+	{
+		if (!HumanSpeechSequence.IsValid())
+		{
+			continue;
+		}
+
+		UDlgNode_SpeechSequence* SequenceNode = Dialogue->ConstructDialogueNode<UDlgNode_SpeechSequence>();
+		SequenceNode->SetNodeParticipantName(HumanSpeechSequence.Speaker);
+		
+		TArray<FDlgSpeechSequenceEntry>& SequenceArray = *SequenceNode->GetMutableNodeSpeechSequence();
+		SequenceArray.Empty();
+		for (const FDlgSpeechSequenceEntry_FormatHumanReadable& HumanSequence : HumanSpeechSequence.Sequence)
+		{
+			FDlgSpeechSequenceEntry Entry;
+			Entry.EdgeText = HumanSequence.EdgeText;
+			Entry.Text = HumanSequence.Text;
+			Entry.Speaker = HumanSequence.Speaker;
+			SequenceArray.Add(Entry);
+		}
+		
+		Dialogue->AddNode(SequenceNode);
+		CreatedNodes.Add(HumanSpeechSequence.NodeIndex, SequenceNode);
+		NodeEdges.Add(HumanSpeechSequence.NodeIndex, HumanSpeechSequence.Edges);
+	}
+
+	// Second pass: wire up edges
+	for (const auto& Pair : NodeEdges)
+	{
+		const int32 SourceIndex = Pair.Key;
+		const TArray<FDlgEdge_FormatHumanReadable>& Edges = Pair.Value;
+		
+		UDlgNode** SourceNodePtr = CreatedNodes.Find(SourceIndex);
+		if (!SourceNodePtr || !*SourceNodePtr)
+		{
+			continue;
+		}
+		
+		UDlgNode* SourceNode = *SourceNodePtr;
+		for (const FDlgEdge_FormatHumanReadable& HumanEdge : Edges)
+		{
+			UDlgNode** TargetNodePtr = CreatedNodes.Find(HumanEdge.TargetNodeIndex);
+			if (!TargetNodePtr || !*TargetNodePtr)
+			{
+				// Target node doesn't exist - create an End node as fallback
+				UDlgNode_End* EndNode = Dialogue->ConstructDialogueNode<UDlgNode_End>();
+				Dialogue->AddNode(EndNode);
+				CreatedNodes.Add(HumanEdge.TargetNodeIndex, EndNode);
+				TargetNodePtr = CreatedNodes.Find(HumanEdge.TargetNodeIndex);
+			}
+			
+			if (TargetNodePtr && *TargetNodePtr)
+			{
+				FDlgEdge Edge;
+				Edge.TargetIndex = HumanEdge.TargetNodeIndex;
+				Edge.SetText(HumanEdge.Text);
+				SourceNode->AddNodeChild(Edge);
+			}
+		}
+	}
+
+	Dialogue->Modify();
+	Dialogue->MarkPackageDirty();
+	
+	// Rebuild the graph from the new dialogue nodes
+	if (UDialogueGraph* DialogueGraph = Cast<UDialogueGraph>(Dialogue->GetGraph()))
+	{
+		DialogueGraph->RemoveAllNodes();
+		DialogueGraph->CreateGraphNodesFromDialogue();
+		DialogueGraph->LinkGraphNodesFromDialogue();
+		DialogueGraph->AutoPositionGraphNodes();
+	}
+	
+	return true;
+}
+
+bool FDlgJsonDialogueHelper::SetGraphNodesNewEdgesText(UDialogueGraphNode* GraphNode, const TArray<FDlgEdge_FormatHumanReadable>& Edges, int32 NodeIndex, const UDlgDialogue* Dialogue)
+{
+	bool bModified = false;
+
+	for (const FDlgEdge_FormatHumanReadable& HumanEdge : Edges)
+	{
+		const int32 EdgeIndex = GraphNode->GetChildEdgeIndexForChildNodeIndex(HumanEdge.TargetNodeIndex);
+		if (EdgeIndex < 0)
+		{
+			continue;
+		}
+
+		if (!GraphNode->GetDialogueNode().GetNodeChildren()[EdgeIndex].GetUnformattedText().EqualTo(HumanEdge.Text))
+		{
+			GraphNode->SetEdgeTextAt(EdgeIndex, HumanEdge.Text);
+			bModified = true;
+		}
+	}
+
+	return bModified;
+}

--- a/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
+++ b/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
@@ -102,11 +102,23 @@ bool FDlgJsonDialogueHelper::ImportDialogueFromJsonDestructive(const FString& Js
 		return false;
 	}
 
-	if (OutError)
+	FDlgJsonParser JsonParser;
+	JsonParser.InitializeParserFromString(JsonString);
+	if (!JsonParser.IsValidFile())
 	{
-		*OutError = TEXT("Destructive JSON import is unsupported because the JSON format does not preserve every dialogue node type and node-specific property.");
+		if (OutError) *OutError = TEXT("Invalid JSON format");
+		return false;
 	}
-	return false;
+
+	FDlgDialogue_FormatHumanReadable HumanFormat;
+	JsonParser.ReadAllProperty(FDlgDialogue_FormatHumanReadable::StaticStruct(), &HumanFormat);
+	if (!JsonParser.IsValidFile())
+	{
+		if (OutError) *OutError = TEXT("Failed to parse dialogue format from JSON");
+		return false;
+	}
+
+	return ImportHumanReadableFormatIntoDialogueDestructive(HumanFormat, Dialogue, OutError);
 }
 
 bool FDlgJsonDialogueHelper::ImportDialogueFromJsonFileDestructive(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError)
@@ -122,11 +134,23 @@ bool FDlgJsonDialogueHelper::ImportDialogueFromJsonFileDestructive(const FString
 		return false;
 	}
 
-	if (OutError)
+	FDlgJsonParser JsonParser;
+	JsonParser.InitializeParser(FilePath);
+	if (!JsonParser.IsValidFile())
 	{
-		*OutError = TEXT("Destructive JSON import is unsupported because the JSON format does not preserve every dialogue node type and node-specific property.");
+		if (OutError) *OutError = FString::Printf(TEXT("Failed to read/parse JSON file: %s"), *FilePath);
+		return false;
 	}
-	return false;
+
+	FDlgDialogue_FormatHumanReadable HumanFormat;
+	JsonParser.ReadAllProperty(FDlgDialogue_FormatHumanReadable::StaticStruct(), &HumanFormat);
+	if (!JsonParser.IsValidFile())
+	{
+		if (OutError) *OutError = TEXT("Failed to parse dialogue format from JSON file");
+		return false;
+	}
+
+	return ImportHumanReadableFormatIntoDialogueDestructive(HumanFormat, Dialogue, OutError);
 }
 
 bool FDlgJsonDialogueHelper::ExportDialogueToHumanReadableFormat(const UDlgDialogue& Dialogue, FDlgDialogue_FormatHumanReadable& OutFormat)
@@ -134,7 +158,7 @@ bool FDlgJsonDialogueHelper::ExportDialogueToHumanReadableFormat(const UDlgDialo
 	OutFormat.DialogueName = Dialogue.GetDialogueFName();
 	OutFormat.DialogueGUID = Dialogue.GetGUID();
 
-	// Start nodes are exported as pseudo speech nodes with negative indices: -1, -2, -3, etc.
+	// Root Nodes
 	const TArray<UDlgNode*> StartNodes = Dialogue.GetStartNodes();
 	for (int32 i = 0; i < StartNodes.Num(); ++i)
 	{
@@ -175,8 +199,8 @@ bool FDlgJsonDialogueHelper::ExportDialogueToHumanReadableFormat(const UDlgDialo
 		}
 		else
 		{
-			// Unsupported node classes are represented only by their index and edges.
-			// This is enough for non-destructive edge-text import, but not for recreating nodes.
+			// Other node types (End, Start, Proxy, Selector, Custom, etc.)
+			// Export as empty speech node so edges are preserved
 			FDlgNodeSpeech_FormatHumanReadable ExportNode;
 			ExportNode.NodeIndex = NodeIndex;
 			ExportNode.Speaker = NAME_None;
@@ -225,34 +249,30 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		return false;
 	}
 
-	// Speech nodes and exported start-node pseudo nodes.
+	// Speech nodes
 	for (const FDlgNodeSpeech_FormatHumanReadable& HumanNode : Format.SpeechNodes)
 	{
-		const bool bIsRootNode = HumanNode.NodeIndex <= RootNodeIndex;
-		if (!bIsRootNode && !HumanNode.IsValid())
+		if (!HumanNode.IsValid())
 		{
 			SkippedNodes++;
 			continue;
 		}
 
-		UDlgNode* Node = nullptr;
-		if (bIsRootNode)
-		{
-			const int32 StartNodeIndex = -HumanNode.NodeIndex - 1;
-			TArray<UDlgNode*>& StartNodes = Dialogue->GetMutableStartNodes();
-			Node = StartNodes.IsValidIndex(StartNodeIndex) ? StartNodes[StartNodeIndex] : nullptr;
-		}
-		else
-		{
-			Node = Dialogue->GetMutableNodeFromIndex(HumanNode.NodeIndex);
-		}
+		const bool bIsRootNode = HumanNode.NodeIndex <= RootNodeIndex;
+		UDlgNode* Node = bIsRootNode
+			? Dialogue->GetMutableStartNodes()[FMath::Abs(RootNodeIndex) - 1]
+			: Dialogue->GetMutableNodeFromIndex(HumanNode.NodeIndex);
 
 		if (Node == nullptr)
 		{
-			MismatchedNodes++;
-			if (OutError && OutError->IsEmpty())
+			if (!bIsRootNode)
 			{
-				*OutError = FString::Printf(TEXT("Node index %d from JSON not found in dialogue."), HumanNode.NodeIndex);
+				MismatchedNodes++;
+				if (OutError && OutError->IsEmpty())
+				{
+					*OutError = FString::Printf(TEXT("Node index %d from JSON not found in dialogue (dialogue has %d nodes)"),
+						HumanNode.NodeIndex, Dialogue->GetNodes().Num());
+				}
 			}
 			continue;
 		}
@@ -274,22 +294,27 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 					bModified = true;
 				}
 			}
+			else
+			{
+				// Node exists but is not a speech node (e.g. End node) - that's ok, just skip text update
+			}
 		}
 
 		UDialogueGraphNode* GraphNode = Cast<UDialogueGraphNode>(Node->GetGraphNode());
-		if (GraphNode != nullptr)
+		if (GraphNode == nullptr)
 		{
-			if (SetGraphNodesNewEdgesText(GraphNode, HumanNode.Edges, HumanNode.NodeIndex, Dialogue))
-			{
-				bModified = true;
-			}
-			GraphNode->CheckAll();
+			continue;
 		}
 
+		if (SetGraphNodesNewEdgesText(GraphNode, HumanNode.Edges, HumanNode.NodeIndex, Dialogue))
+		{
+			bModified = true;
+		}
+		GraphNode->CheckAll();
 		ProcessedNodes++;
 	}
 
-	// Speech sequence nodes.
+	// Speech sequence nodes
 	for (const FDlgNodeSpeechSequence_FormatHumanReadable& HumanSpeechSequence : Format.SpeechSequenceNodes)
 	{
 		if (!HumanSpeechSequence.IsValid())
@@ -352,15 +377,16 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		}
 
 		UDialogueGraphNode* GraphNode = Cast<UDialogueGraphNode>(Node->GetGraphNode());
-		if (GraphNode != nullptr)
+		if (GraphNode == nullptr)
 		{
-			if (SetGraphNodesNewEdgesText(GraphNode, HumanSpeechSequence.Edges, HumanSpeechSequence.NodeIndex, Dialogue))
-			{
-				bModified = true;
-			}
-			GraphNode->CheckAll();
+			continue;
 		}
 
+		if (SetGraphNodesNewEdgesText(GraphNode, HumanSpeechSequence.Edges, HumanSpeechSequence.NodeIndex, Dialogue))
+		{
+			bModified = true;
+		}
+		GraphNode->CheckAll();
 		ProcessedNodes++;
 	}
 
@@ -370,29 +396,151 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		Dialogue->MarkPackageDirty();
 	}
 
-	if (ProcessedNodes == 0)
-	{
-		if (OutError && OutError->IsEmpty())
-		{
-			*OutError = SkippedNodes > 0
-				? TEXT("Import completed but no nodes were processed. All JSON nodes were invalid or incompatible.")
-				: TEXT("Import completed but no nodes were processed.");
-		}
-		return false;
-	}
-
-	if (OutError && OutError->IsEmpty())
+	if (!bModified && OutError && OutError->IsEmpty())
 	{
 		if (MismatchedNodes > 0)
 		{
-			*OutError = FString::Printf(TEXT("Import completed with %d unmatched node(s). Matching nodes were processed."), MismatchedNodes);
+			*OutError = FString::Printf(TEXT("Import completed but no changes were made. %d node(s) from JSON did not match the dialogue structure. The dialogue may have a different node count or node types than the JSON file."), MismatchedNodes);
 		}
-		else if (!bModified)
+		else if (ProcessedNodes == 0)
 		{
-			*OutError = TEXT("Import completed successfully. No changes were needed because the dialogue already matched the JSON.");
+			*OutError = TEXT("Import completed but no nodes were processed. The JSON file may be empty or all nodes were invalid.");
+		}
+		else
+		{
+			*OutError = TEXT("Import completed but no changes were needed. All text/speaker/edge data already matches.");
 		}
 	}
 
+	return bModified;
+}
+
+bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogueDestructive(
+	const FDlgDialogue_FormatHumanReadable& Format, UDlgDialogue* Dialogue, FString* OutError)
+{
+	verify(Dialogue);
+
+	if (Format.SpeechNodes.Num() == 0 && Format.SpeechSequenceNodes.Num() == 0)
+	{
+		if (OutError) *OutError = TEXT("No speech nodes or speech sequence nodes found in JSON");
+		return false;
+	}
+
+	// Clear existing graph and dialogue data
+	// IMPORTANT: Clear graph first to remove stale graph node references
+	if (Dialogue->GetGraph())
+	{
+		Dialogue->ClearGraph();
+	}
+	Dialogue->SetStartNodes(TArray<UDlgNode*>());
+	Dialogue->SetNodes(TArray<UDlgNode*>());
+
+	// Maps JSON node index -> created UDlgNode*
+	TMap<int32, UDlgNode*> CreatedNodes;
+	TMap<int32, TArray<FDlgEdge_FormatHumanReadable>> NodeEdges;
+
+	// First pass: create all nodes
+	for (const FDlgNodeSpeech_FormatHumanReadable& HumanNode : Format.SpeechNodes)
+	{
+		if (!HumanNode.IsValid())
+		{
+			continue;
+		}
+
+		const bool bIsRootNode = HumanNode.NodeIndex <= RootNodeIndex;
+		if (bIsRootNode)
+		{
+			// Create start node
+			UDlgNode_Start* StartNode = Dialogue->ConstructDialogueNode<UDlgNode_Start>();
+			Dialogue->AddStartNode(StartNode);
+			CreatedNodes.Add(HumanNode.NodeIndex, StartNode);
+			NodeEdges.Add(HumanNode.NodeIndex, HumanNode.Edges);
+		}
+		else
+		{
+			// Create speech node
+			UDlgNode_Speech* SpeechNode = Dialogue->ConstructDialogueNode<UDlgNode_Speech>();
+			SpeechNode->SetNodeParticipantName(HumanNode.Speaker);
+			SpeechNode->SetNodeText(HumanNode.Text);
+			Dialogue->AddNode(SpeechNode);
+			CreatedNodes.Add(HumanNode.NodeIndex, SpeechNode);
+			NodeEdges.Add(HumanNode.NodeIndex, HumanNode.Edges);
+		}
+	}
+
+	for (const FDlgNodeSpeechSequence_FormatHumanReadable& HumanSpeechSequence : Format.SpeechSequenceNodes)
+	{
+		if (!HumanSpeechSequence.IsValid())
+		{
+			continue;
+		}
+
+		UDlgNode_SpeechSequence* SequenceNode = Dialogue->ConstructDialogueNode<UDlgNode_SpeechSequence>();
+		SequenceNode->SetNodeParticipantName(HumanSpeechSequence.Speaker);
+		
+		TArray<FDlgSpeechSequenceEntry>& SequenceArray = *SequenceNode->GetMutableNodeSpeechSequence();
+		SequenceArray.Empty();
+		for (const FDlgSpeechSequenceEntry_FormatHumanReadable& HumanSequence : HumanSpeechSequence.Sequence)
+		{
+			FDlgSpeechSequenceEntry Entry;
+			Entry.EdgeText = HumanSequence.EdgeText;
+			Entry.Text = HumanSequence.Text;
+			Entry.Speaker = HumanSequence.Speaker;
+			SequenceArray.Add(Entry);
+		}
+		
+		Dialogue->AddNode(SequenceNode);
+		CreatedNodes.Add(HumanSpeechSequence.NodeIndex, SequenceNode);
+		NodeEdges.Add(HumanSpeechSequence.NodeIndex, HumanSpeechSequence.Edges);
+	}
+
+	// Second pass: wire up edges
+	for (const auto& Pair : NodeEdges)
+	{
+		const int32 SourceIndex = Pair.Key;
+		const TArray<FDlgEdge_FormatHumanReadable>& Edges = Pair.Value;
+		
+		UDlgNode** SourceNodePtr = CreatedNodes.Find(SourceIndex);
+		if (!SourceNodePtr || !*SourceNodePtr)
+		{
+			continue;
+		}
+		
+		UDlgNode* SourceNode = *SourceNodePtr;
+		for (const FDlgEdge_FormatHumanReadable& HumanEdge : Edges)
+		{
+			UDlgNode** TargetNodePtr = CreatedNodes.Find(HumanEdge.TargetNodeIndex);
+			if (!TargetNodePtr || !*TargetNodePtr)
+			{
+				// Target node doesn't exist - create an End node as fallback
+				UDlgNode_End* EndNode = Dialogue->ConstructDialogueNode<UDlgNode_End>();
+				Dialogue->AddNode(EndNode);
+				CreatedNodes.Add(HumanEdge.TargetNodeIndex, EndNode);
+				TargetNodePtr = CreatedNodes.Find(HumanEdge.TargetNodeIndex);
+			}
+			
+			if (TargetNodePtr && *TargetNodePtr)
+			{
+				FDlgEdge Edge;
+				Edge.TargetIndex = HumanEdge.TargetNodeIndex;
+				Edge.SetText(HumanEdge.Text);
+				SourceNode->AddNodeChild(Edge);
+			}
+		}
+	}
+
+	Dialogue->Modify();
+	Dialogue->MarkPackageDirty();
+	
+	// Rebuild the graph from the new dialogue nodes
+	if (UDialogueGraph* DialogueGraph = Cast<UDialogueGraph>(Dialogue->GetGraph()))
+	{
+		DialogueGraph->RemoveAllNodes();
+		DialogueGraph->CreateGraphNodesFromDialogue();
+		DialogueGraph->LinkGraphNodesFromDialogue();
+		DialogueGraph->AutoPositionGraphNodes();
+	}
+	
 	return true;
 }
 

--- a/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
+++ b/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
@@ -25,7 +25,7 @@ bool FDlgJsonDialogueHelper::ExportDialogueToJson(const UDlgDialogue* Dialogue, 
 	return !OutJsonString.IsEmpty();
 }
 
-bool FDlgJsonDialogueHelper::ImportDialogueFromJson(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError)
+bool FDlgJsonDialogueHelper::ImportDialogueNodeUpdatesFromJson(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError)
 {
 	if (!IsValid(Dialogue))
 	{
@@ -57,7 +57,7 @@ bool FDlgJsonDialogueHelper::ImportDialogueFromJson(const FString& JsonString, U
 	return ImportHumanReadableFormatIntoDialogue(HumanFormat, Dialogue, OutError);
 }
 
-bool FDlgJsonDialogueHelper::ImportDialogueFromJsonFile(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError)
+bool FDlgJsonDialogueHelper::ImportDialogueNodeUpdatesFromJsonFile(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError)
 {
 	if (!IsValid(Dialogue))
 	{
@@ -89,7 +89,7 @@ bool FDlgJsonDialogueHelper::ImportDialogueFromJsonFile(const FString& FilePath,
 	return ImportHumanReadableFormatIntoDialogue(HumanFormat, Dialogue, OutError);
 }
 
-bool FDlgJsonDialogueHelper::ImportDialogueFromJsonDestructive(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError)
+bool FDlgJsonDialogueHelper::ImportDialogueFromJsonAsReplacement(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError)
 {
 	if (!IsValid(Dialogue))
 	{
@@ -121,7 +121,7 @@ bool FDlgJsonDialogueHelper::ImportDialogueFromJsonDestructive(const FString& Js
 	return ImportHumanReadableFormatIntoDialogueDestructive(HumanFormat, Dialogue, OutError);
 }
 
-bool FDlgJsonDialogueHelper::ImportDialogueFromJsonFileDestructive(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError)
+bool FDlgJsonDialogueHelper::ImportDialogueFromJsonFileAsReplacement(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError)
 {
 	if (!IsValid(Dialogue))
 	{

--- a/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
+++ b/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
@@ -240,6 +240,7 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 
 	bool bModified = false;
 	int32 ProcessedNodes = 0;
+	int32 MismatchedNodes = 0;
 
 	if (Format.SpeechNodes.Num() == 0 && Format.SpeechSequenceNodes.Num() == 0)
 	{
@@ -339,6 +340,7 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		UDlgNode* Node = Dialogue->GetMutableNodeFromIndex(HumanSpeechSequence.NodeIndex);
 		if (Node == nullptr)
 		{
+			MismatchedNodes++;
 			if (OutError && OutError->IsEmpty())
 			{
 				*OutError = FString::Printf(TEXT("Speech sequence node index %d from JSON not found in dialogue (dialogue has %d nodes)"),
@@ -350,6 +352,7 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		UDlgNode_SpeechSequence* NodeSpeechSequence = Cast<UDlgNode_SpeechSequence>(Node);
 		if (NodeSpeechSequence == nullptr)
 		{
+			MismatchedNodes++;
 			if (OutError && OutError->IsEmpty())
 			{
 				*OutError = FString::Printf(TEXT("Node index %d is not a speech sequence node in the dialogue"), HumanSpeechSequence.NodeIndex);
@@ -411,7 +414,14 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 	{
 		if (OutError && OutError->IsEmpty())
 		{
-			*OutError = TEXT("Import completed but no nodes were processed. The JSON file may be empty or all nodes were invalid.");
+			if (MismatchedNodes > 0)
+			{
+				*OutError = FString::Printf(TEXT("Import failed. %d node(s) from JSON did not match the dialogue structure."), MismatchedNodes);
+			}
+			else
+			{
+				*OutError = TEXT("Import completed but no nodes were processed. The JSON file may be empty or all nodes were invalid.");
+			}
 		}
 		return false;
 	}

--- a/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
+++ b/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
@@ -240,8 +240,6 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 
 	bool bModified = false;
 	int32 ProcessedNodes = 0;
-	int32 SkippedNodes = 0;
-	int32 MismatchedNodes = 0;
 
 	if (Format.SpeechNodes.Num() == 0 && Format.SpeechSequenceNodes.Num() == 0)
 	{
@@ -254,7 +252,6 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 	{
 		if (!HumanNode.IsValid())
 		{
-			SkippedNodes++;
 			continue;
 		}
 
@@ -267,7 +264,6 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		{
 			if (!bIsRootNode)
 			{
-				MismatchedNodes++;
 				if (OutError && OutError->IsEmpty())
 				{
 					*OutError = FString::Printf(TEXT("Node index %d from JSON not found in dialogue (dialogue has %d nodes)"),
@@ -319,14 +315,12 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 	{
 		if (!HumanSpeechSequence.IsValid())
 		{
-			SkippedNodes++;
 			continue;
 		}
 
 		UDlgNode* Node = Dialogue->GetMutableNodeFromIndex(HumanSpeechSequence.NodeIndex);
 		if (Node == nullptr)
 		{
-			MismatchedNodes++;
 			if (OutError && OutError->IsEmpty())
 			{
 				*OutError = FString::Printf(TEXT("Speech sequence node index %d from JSON not found in dialogue (dialogue has %d nodes)"),
@@ -338,7 +332,6 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		UDlgNode_SpeechSequence* NodeSpeechSequence = Cast<UDlgNode_SpeechSequence>(Node);
 		if (NodeSpeechSequence == nullptr)
 		{
-			MismatchedNodes++;
 			if (OutError && OutError->IsEmpty())
 			{
 				*OutError = FString::Printf(TEXT("Node index %d is not a speech sequence node in the dialogue"), HumanSpeechSequence.NodeIndex);
@@ -396,23 +389,16 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		Dialogue->MarkPackageDirty();
 	}
 
-	if (!bModified && OutError && OutError->IsEmpty())
+	if (ProcessedNodes == 0)
 	{
-		if (MismatchedNodes > 0)
-		{
-			*OutError = FString::Printf(TEXT("Import completed but no changes were made. %d node(s) from JSON did not match the dialogue structure. The dialogue may have a different node count or node types than the JSON file."), MismatchedNodes);
-		}
-		else if (ProcessedNodes == 0)
+		if (OutError && OutError->IsEmpty())
 		{
 			*OutError = TEXT("Import completed but no nodes were processed. The JSON file may be empty or all nodes were invalid.");
 		}
-		else
-		{
-			*OutError = TEXT("Import completed but no changes were needed. All text/speaker/edge data already matches.");
-		}
+		return false;
 	}
 
-	return bModified;
+	return true;
 }
 
 bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogueDestructive(
@@ -435,8 +421,9 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogueDestructive(
 	Dialogue->SetStartNodes(TArray<UDlgNode*>());
 	Dialogue->SetNodes(TArray<UDlgNode*>());
 
-	// Maps JSON node index -> created UDlgNode*
+	// Maps JSON node indices to rebuilt dialogue data.
 	TMap<int32, UDlgNode*> CreatedNodes;
+	TMap<int32, int32> OldNodeIndexToNewNodeIndex;
 	TMap<int32, TArray<FDlgEdge_FormatHumanReadable>> NodeEdges;
 
 	// First pass: create all nodes
@@ -462,8 +449,9 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogueDestructive(
 			UDlgNode_Speech* SpeechNode = Dialogue->ConstructDialogueNode<UDlgNode_Speech>();
 			SpeechNode->SetNodeParticipantName(HumanNode.Speaker);
 			SpeechNode->SetNodeText(HumanNode.Text);
-			Dialogue->AddNode(SpeechNode);
+			const int32 NewNodeIndex = Dialogue->AddNode(SpeechNode);
 			CreatedNodes.Add(HumanNode.NodeIndex, SpeechNode);
+			OldNodeIndexToNewNodeIndex.Add(HumanNode.NodeIndex, NewNodeIndex);
 			NodeEdges.Add(HumanNode.NodeIndex, HumanNode.Edges);
 		}
 	}
@@ -489,8 +477,9 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogueDestructive(
 			SequenceArray.Add(Entry);
 		}
 		
-		Dialogue->AddNode(SequenceNode);
+		const int32 NewNodeIndex = Dialogue->AddNode(SequenceNode);
 		CreatedNodes.Add(HumanSpeechSequence.NodeIndex, SequenceNode);
+		OldNodeIndexToNewNodeIndex.Add(HumanSpeechSequence.NodeIndex, NewNodeIndex);
 		NodeEdges.Add(HumanSpeechSequence.NodeIndex, HumanSpeechSequence.Edges);
 	}
 
@@ -514,15 +503,22 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogueDestructive(
 			{
 				// Target node doesn't exist - create an End node as fallback
 				UDlgNode_End* EndNode = Dialogue->ConstructDialogueNode<UDlgNode_End>();
-				Dialogue->AddNode(EndNode);
+				const int32 NewNodeIndex = Dialogue->AddNode(EndNode);
 				CreatedNodes.Add(HumanEdge.TargetNodeIndex, EndNode);
+				OldNodeIndexToNewNodeIndex.Add(HumanEdge.TargetNodeIndex, NewNodeIndex);
 				TargetNodePtr = CreatedNodes.Find(HumanEdge.TargetNodeIndex);
 			}
 			
 			if (TargetNodePtr && *TargetNodePtr)
 			{
+				const int32* NewTargetIndex = OldNodeIndexToNewNodeIndex.Find(HumanEdge.TargetNodeIndex);
+				if (NewTargetIndex == nullptr)
+				{
+					continue;
+				}
+
 				FDlgEdge Edge;
-				Edge.TargetIndex = HumanEdge.TargetNodeIndex;
+				Edge.TargetIndex = *NewTargetIndex;
 				Edge.SetText(HumanEdge.Text);
 				SourceNode->AddNodeChild(Edge);
 			}

--- a/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
+++ b/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.cpp
@@ -256,14 +256,32 @@ bool FDlgJsonDialogueHelper::ImportHumanReadableFormatIntoDialogue(const FDlgDia
 		}
 
 		const bool bIsRootNode = HumanNode.NodeIndex <= RootNodeIndex;
-		UDlgNode* Node = bIsRootNode
-			? Dialogue->GetMutableStartNodes()[FMath::Abs(RootNodeIndex) - 1]
-			: Dialogue->GetMutableNodeFromIndex(HumanNode.NodeIndex);
+		const int32 StartNodeIndex = FMath::Abs(HumanNode.NodeIndex) - 1;
+		UDlgNode* Node = nullptr;
+		if (bIsRootNode)
+		{
+			TArray<UDlgNode*>& StartNodes = Dialogue->GetMutableStartNodes();
+			Node = StartNodes.IsValidIndex(StartNodeIndex) ? StartNodes[StartNodeIndex] : nullptr;
+		}
+		else
+		{
+			Node = Dialogue->GetMutableNodeFromIndex(HumanNode.NodeIndex);
+		}
 
 		if (Node == nullptr)
 		{
-			if (!bIsRootNode)
+			if (bIsRootNode)
 			{
+				MismatchedNodes++;
+				if (OutError && OutError->IsEmpty())
+				{
+					*OutError = FString::Printf(TEXT("Start node index %d from JSON not found in dialogue (dialogue has %d start nodes)"),
+						StartNodeIndex, Dialogue->GetStartNodes().Num());
+				}
+			}
+			else
+			{
+				MismatchedNodes++;
 				if (OutError && OutError->IsEmpty())
 				{
 					*OutError = FString::Printf(TEXT("Node index %d from JSON not found in dialogue (dialogue has %d nodes)"),

--- a/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.h
+++ b/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.h
@@ -1,0 +1,29 @@
+// Copyright Csaba Molnar, Daniel Butum. All Rights Reserved.
+#pragma once
+
+#include "DlgSystem/DlgDialogue.h"
+#include "DlgSystem/Nodes/DlgNode_Speech.h"
+#include "DlgSystem/Nodes/DlgNode_SpeechSequence.h"
+#include "DlgSystem/Nodes/DlgNode_End.h"
+#include "DlgSystemEditor/Editor/Nodes/DialogueGraphNode.h"
+#include "DlgSystemEditor/Editor/Graph/DialogueGraph.h"
+#include "DlgSystemEditor/Commandlets/DlgHumanReadableTextCommandlet.h"
+
+class DLGSYSTEMEDITOR_API FDlgJsonDialogueHelper
+{
+public:
+	static bool ExportDialogueToJson(const UDlgDialogue* Dialogue, FString& OutJsonString);
+	static bool ImportDialogueFromJson(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+	static bool ImportDialogueFromJsonFile(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+	static bool ImportDialogueFromJsonDestructive(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+	static bool ImportDialogueFromJsonFileDestructive(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+
+private:
+	static bool ExportDialogueToHumanReadableFormat(const UDlgDialogue& Dialogue, FDlgDialogue_FormatHumanReadable& OutFormat);
+	static void ExportNodeEdgesToHumanReadableFormat(const TArray<FDlgEdge>& Edges, TArray<FDlgEdge_FormatHumanReadable>& OutEdges);
+	static bool ImportHumanReadableFormatIntoDialogue(const FDlgDialogue_FormatHumanReadable& Format, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+	static bool ImportHumanReadableFormatIntoDialogueDestructive(const FDlgDialogue_FormatHumanReadable& Format, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+	static bool SetGraphNodesNewEdgesText(UDialogueGraphNode* GraphNode, const TArray<FDlgEdge_FormatHumanReadable>& Edges, int32 NodeIndex, const UDlgDialogue* Dialogue);
+
+	static constexpr int32 RootNodeIndex = INDEX_NONE;
+};

--- a/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.h
+++ b/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.h
@@ -12,17 +12,25 @@
 class DLGSYSTEMEDITOR_API FDlgJsonDialogueHelper
 {
 public:
+	/** Serializes a dialogue into the existing human-readable dialogue structure, then writes it as JSON. */
 	static bool ExportDialogueToJson(const UDlgDialogue* Dialogue, FString& OutJsonString);
+
+	/** Imports JSON as non-overwriting text, speaker, and edge updates into the existing dialogue graph. */
 	static bool ImportDialogueFromJson(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+
+	/** File-based wrapper for ImportDialogueFromJson. */
 	static bool ImportDialogueFromJsonFile(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+
+	/** Unsupported because this JSON format does not preserve every dialogue node type and node-specific property. */
 	static bool ImportDialogueFromJsonDestructive(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+
+	/** File-based wrapper for the unsupported full-overwrite import path. */
 	static bool ImportDialogueFromJsonFileDestructive(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError = nullptr);
 
 private:
 	static bool ExportDialogueToHumanReadableFormat(const UDlgDialogue& Dialogue, FDlgDialogue_FormatHumanReadable& OutFormat);
 	static void ExportNodeEdgesToHumanReadableFormat(const TArray<FDlgEdge>& Edges, TArray<FDlgEdge_FormatHumanReadable>& OutEdges);
 	static bool ImportHumanReadableFormatIntoDialogue(const FDlgDialogue_FormatHumanReadable& Format, UDlgDialogue* Dialogue, FString* OutError = nullptr);
-	static bool ImportHumanReadableFormatIntoDialogueDestructive(const FDlgDialogue_FormatHumanReadable& Format, UDlgDialogue* Dialogue, FString* OutError = nullptr);
 	static bool SetGraphNodesNewEdgesText(UDialogueGraphNode* GraphNode, const TArray<FDlgEdge_FormatHumanReadable>& Edges, int32 NodeIndex, const UDlgDialogue* Dialogue);
 
 	static constexpr int32 RootNodeIndex = INDEX_NONE;

--- a/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.h
+++ b/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.h
@@ -12,11 +12,20 @@
 class DLGSYSTEMEDITOR_API FDlgJsonDialogueHelper
 {
 public:
+	// Exports a dialogue to the human-readable dialogue JSON format.
 	static bool ExportDialogueToJson(const UDlgDialogue* Dialogue, FString& OutJsonString);
-	static bool ImportDialogueFromJson(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError = nullptr);
-	static bool ImportDialogueFromJsonFile(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError = nullptr);
-	static bool ImportDialogueFromJsonDestructive(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError = nullptr);
-	static bool ImportDialogueFromJsonFileDestructive(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+
+	// Imports text, speaker, and edge text updates from JSON into matching existing dialogue nodes only.
+	static bool ImportDialogueNodeUpdatesFromJson(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+
+	// Imports text, speaker, and edge text updates from a JSON file into matching existing dialogue nodes only.
+	static bool ImportDialogueNodeUpdatesFromJsonFile(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+
+	// Replaces the dialogue nodes and graph with nodes recreated from JSON.
+	static bool ImportDialogueFromJsonAsReplacement(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+
+	// Replaces the dialogue nodes and graph with nodes recreated from a JSON file.
+	static bool ImportDialogueFromJsonFileAsReplacement(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError = nullptr);
 
 private:
 	static bool ExportDialogueToHumanReadableFormat(const UDlgDialogue& Dialogue, FDlgDialogue_FormatHumanReadable& OutFormat);

--- a/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.h
+++ b/Source/DlgSystemEditor/IO/DlgJsonDialogueHelper.h
@@ -12,25 +12,17 @@
 class DLGSYSTEMEDITOR_API FDlgJsonDialogueHelper
 {
 public:
-	/** Serializes a dialogue into the existing human-readable dialogue structure, then writes it as JSON. */
 	static bool ExportDialogueToJson(const UDlgDialogue* Dialogue, FString& OutJsonString);
-
-	/** Imports JSON as non-overwriting text, speaker, and edge updates into the existing dialogue graph. */
 	static bool ImportDialogueFromJson(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError = nullptr);
-
-	/** File-based wrapper for ImportDialogueFromJson. */
 	static bool ImportDialogueFromJsonFile(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError = nullptr);
-
-	/** Unsupported because this JSON format does not preserve every dialogue node type and node-specific property. */
 	static bool ImportDialogueFromJsonDestructive(const FString& JsonString, UDlgDialogue* Dialogue, FString* OutError = nullptr);
-
-	/** File-based wrapper for the unsupported full-overwrite import path. */
 	static bool ImportDialogueFromJsonFileDestructive(const FString& FilePath, UDlgDialogue* Dialogue, FString* OutError = nullptr);
 
 private:
 	static bool ExportDialogueToHumanReadableFormat(const UDlgDialogue& Dialogue, FDlgDialogue_FormatHumanReadable& OutFormat);
 	static void ExportNodeEdgesToHumanReadableFormat(const TArray<FDlgEdge>& Edges, TArray<FDlgEdge_FormatHumanReadable>& OutEdges);
 	static bool ImportHumanReadableFormatIntoDialogue(const FDlgDialogue_FormatHumanReadable& Format, UDlgDialogue* Dialogue, FString* OutError = nullptr);
+	static bool ImportHumanReadableFormatIntoDialogueDestructive(const FDlgDialogue_FormatHumanReadable& Format, UDlgDialogue* Dialogue, FString* OutError = nullptr);
 	static bool SetGraphNodesNewEdgesText(UDialogueGraphNode* GraphNode, const TArray<FDlgEdge_FormatHumanReadable>& Edges, int32 NodeIndex, const UDlgDialogue* Dialogue);
 
 	static constexpr int32 RootNodeIndex = INDEX_NONE;


### PR DESCRIPTION
Added json support so it's easier to import/export! :)

### Added
- FDlgJsonDialogueHelper — static utility class with 5 methods:
  - ExportDialogueToJson — serializes a dialogue to a JSON string
  - ImportDialogueFromJson — updates existing nodes from JSON
  - ImportDialogueFromJsonFile — file-based wrapper for the above
  - ImportDialogueFromJsonDestructive — full destructive overwrite from JSON
  - ImportDialogueFromJsonFileDestructive — file-based wrapper for the above
- Toolbar buttons in the Dialogue Editor: Import JSON... and Export JSON...
- File picker dialogs for .dlg_human.json files
- Non-destructive import with fallback to destructive overwrite (with confirmation warning)

### Design notes
- Reuses existing FDlgJsonWriter / FDlgJsonParser and FDlgDialogue_FormatHumanReadable
- No changes to the runtime DlgSystem module
- Adds DesktopPlatform dependency to DlgSystemEditor.Build.cs for file dialogs